### PR TITLE
[FEAT] 평가자 리뷰 생성 및 조회 API 구현

### DIFF
--- a/src/main/java/or/hyu/ssd/domain/document/controller/EvaluatorReviewController.java
+++ b/src/main/java/or/hyu/ssd/domain/document/controller/EvaluatorReviewController.java
@@ -1,0 +1,49 @@
+package or.hyu.ssd.domain.document.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import or.hyu.ssd.domain.document.controller.dto.EvaluatorReviewRequest;
+import or.hyu.ssd.domain.document.controller.dto.EvaluatorReviewResponse;
+import or.hyu.ssd.domain.document.service.EvaluatorReviewService;
+import or.hyu.ssd.domain.member.service.CustomUserDetails;
+import or.hyu.ssd.global.api.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+@Tag(name = "평가자 리뷰 API")
+public class EvaluatorReviewController {
+
+    private final EvaluatorReviewService evaluatorReviewService;
+
+    @PostMapping("/v1/documents/{documentId}/evaluator-reviews")
+    @Operation(summary = "평가자 리뷰 저장/수정", description = "세 개의 고정 항목(사업타당성/사업차별성/재무적정성)에 대한 점수와 코멘트를 저장하고, 전체 평균을 계산합니다.")
+    public ResponseEntity<ApiResponse<EvaluatorReviewResponse>> submit(
+            @PathVariable Long documentId,
+            @Valid @RequestBody EvaluatorReviewRequest request,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        EvaluatorReviewResponse dto = evaluatorReviewService.submit(documentId, user, request);
+        return ResponseEntity.ok(ApiResponse.ok(dto, "평가자 리뷰가 저장되었습니다"));
+    }
+
+    @GetMapping("/v1/documents/{documentId}/evaluator-reviews")
+    @Operation(summary = "평가자 리뷰 조회", description = "문서에 저장된 평가자 리뷰 목록과 항목별/전체 평균 점수를 조회합니다.")
+    public ResponseEntity<ApiResponse<EvaluatorReviewResponse>> get(
+            @PathVariable Long documentId,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        EvaluatorReviewResponse dto = evaluatorReviewService.get(documentId, user);
+        return ResponseEntity.ok(ApiResponse.ok(dto, "평가자 리뷰가 조회되었습니다"));
+    }
+}

--- a/src/main/java/or/hyu/ssd/domain/document/controller/dto/EvaluatorReviewItemResponse.java
+++ b/src/main/java/or/hyu/ssd/domain/document/controller/dto/EvaluatorReviewItemResponse.java
@@ -1,0 +1,29 @@
+package or.hyu.ssd.domain.document.controller.dto;
+
+import or.hyu.ssd.domain.document.entity.EvaluatorReview;
+
+public record EvaluatorReviewItemResponse(
+        Long reviewId,
+        Long reviewerId,
+        String reviewerName,
+        int feasibility,
+        int differentiation,
+        int financial,
+        double total,
+        String comment
+) {
+    public static EvaluatorReviewItemResponse of(EvaluatorReview review) {
+        Long reviewerId = review.getReviewer() != null ? review.getReviewer().getId() : null;
+        String reviewerName = review.getReviewer() != null ? review.getReviewer().getName() : null;
+        return new EvaluatorReviewItemResponse(
+                review.getId(),
+                reviewerId,
+                reviewerName,
+                review.getScoreFeasibility(),
+                review.getScoreDifferentiation(),
+                review.getScoreFinancial(),
+                review.getScoreTotal(),
+                review.getComment()
+        );
+    }
+}

--- a/src/main/java/or/hyu/ssd/domain/document/controller/dto/EvaluatorReviewRequest.java
+++ b/src/main/java/or/hyu/ssd/domain/document/controller/dto/EvaluatorReviewRequest.java
@@ -1,0 +1,12 @@
+package or.hyu.ssd.domain.document.controller.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public record EvaluatorReviewRequest(
+        @NotNull @Min(0) @Max(100) Integer feasibility,
+        @NotNull @Min(0) @Max(100) Integer differentiation,
+        @NotNull @Min(0) @Max(100) Integer financial,
+        String comment
+) {}

--- a/src/main/java/or/hyu/ssd/domain/document/controller/dto/EvaluatorReviewResponse.java
+++ b/src/main/java/or/hyu/ssd/domain/document/controller/dto/EvaluatorReviewResponse.java
@@ -1,0 +1,13 @@
+package or.hyu.ssd.domain.document.controller.dto;
+
+import java.util.List;
+
+public record EvaluatorReviewResponse(
+        EvaluatorReviewSummaryResponse summary,
+        List<EvaluatorReviewItemResponse> reviews
+) {
+    public static EvaluatorReviewResponse of(EvaluatorReviewSummaryResponse summary, List<EvaluatorReviewItemResponse> reviews) {
+        List<EvaluatorReviewItemResponse> safe = reviews == null ? List.of() : reviews;
+        return new EvaluatorReviewResponse(summary, safe);
+    }
+}

--- a/src/main/java/or/hyu/ssd/domain/document/controller/dto/EvaluatorReviewSummaryResponse.java
+++ b/src/main/java/or/hyu/ssd/domain/document/controller/dto/EvaluatorReviewSummaryResponse.java
@@ -1,0 +1,14 @@
+package or.hyu.ssd.domain.document.controller.dto;
+
+public record EvaluatorReviewSummaryResponse(
+        Long documentId,
+        double feasibilityAvg,
+        double differentiationAvg,
+        double financialAvg,
+        double totalAvg,
+        int reviewCount
+) {
+    public static EvaluatorReviewSummaryResponse of(Long documentId, double feasibilityAvg, double differentiationAvg, double financialAvg, double totalAvg, int reviewCount) {
+        return new EvaluatorReviewSummaryResponse(documentId, feasibilityAvg, differentiationAvg, financialAvg, totalAvg, reviewCount);
+    }
+}

--- a/src/main/java/or/hyu/ssd/domain/document/entity/Document.java
+++ b/src/main/java/or/hyu/ssd/domain/document/entity/Document.java
@@ -46,6 +46,26 @@ public class Document extends BaseEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
+    @Comment("평가자 리뷰 - 사업타당성 평균 점수")
+    @Column(name = "review_feasibility_avg")
+    private Double reviewFeasibilityAvg;
+
+    @Comment("평가자 리뷰 - 사업차별성 평균 점수")
+    @Column(name = "review_differentiation_avg")
+    private Double reviewDifferentiationAvg;
+
+    @Comment("평가자 리뷰 - 재무적정성 평균 점수")
+    @Column(name = "review_financial_avg")
+    private Double reviewFinancialAvg;
+
+    @Comment("평가자 리뷰 - 전체 평균 점수")
+    @Column(name = "review_total_avg")
+    private Double reviewTotalAvg;
+
+    @Comment("평가자 리뷰 - 참여 평가자 수")
+    @Column(name = "review_count")
+    private Integer reviewCount;
+
     @Version
     private Long version;
 
@@ -81,5 +101,13 @@ public class Document extends BaseEntity {
 
     public void updateDetails(String details) {
         this.details = details;
+    }
+
+    public void updateReviewSummary(Double feasibilityAvg, Double differentiationAvg, Double financialAvg, Double totalAvg, Integer count) {
+        this.reviewFeasibilityAvg = feasibilityAvg;
+        this.reviewDifferentiationAvg = differentiationAvg;
+        this.reviewFinancialAvg = financialAvg;
+        this.reviewTotalAvg = totalAvg;
+        this.reviewCount = count;
     }
 }

--- a/src/main/java/or/hyu/ssd/domain/document/entity/EvaluatorReview.java
+++ b/src/main/java/or/hyu/ssd/domain/document/entity/EvaluatorReview.java
@@ -1,0 +1,84 @@
+package or.hyu.ssd.domain.document.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import or.hyu.ssd.domain.member.entity.Member;
+import or.hyu.ssd.global.entity.BaseEntity;
+import org.hibernate.annotations.Comment;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+@Builder
+@Table(
+        name = "evaluator_reviews",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_evaluator_review_doc_member", columnNames = {"document_id", "member_id"})
+        },
+        indexes = {
+                @Index(name = "idx_evaluator_review_document_id", columnList = "document_id"),
+                @Index(name = "idx_evaluator_review_member_id", columnList = "member_id")
+        }
+)
+public class EvaluatorReview extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Comment("사업타당성 점수 (0~100)")
+    @Column(name = "score_feasibility", nullable = false)
+    private int scoreFeasibility;
+
+    @Comment("사업차별성 점수 (0~100)")
+    @Column(name = "score_differentiation", nullable = false)
+    private int scoreDifferentiation;
+
+    @Comment("재무적정성 점수 (0~100)")
+    @Column(name = "score_financial", nullable = false)
+    private int scoreFinancial;
+
+    @Comment("평가자 코멘트")
+    @Column(name = "comment", columnDefinition = "TEXT")
+    private String comment;
+
+    @Comment("세 항목 평균 점수 (0~100)")
+    @Column(name = "score_total", nullable = false)
+    private double scoreTotal;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "document_id")
+    private Document document;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member reviewer;
+
+    @Version
+    private Long version;
+
+    public static EvaluatorReview of(int feasibility, int differentiation, int financial, String comment, Document doc, Member reviewer) {
+        return EvaluatorReview.builder()
+                .scoreFeasibility(feasibility)
+                .scoreDifferentiation(differentiation)
+                .scoreFinancial(financial)
+                .comment(comment)
+                .scoreTotal(average(feasibility, differentiation, financial))
+                .document(doc)
+                .reviewer(reviewer)
+                .build();
+    }
+
+    public void updateScores(int feasibility, int differentiation, int financial, String comment) {
+        this.scoreFeasibility = feasibility;
+        this.scoreDifferentiation = differentiation;
+        this.scoreFinancial = financial;
+        this.comment = comment;
+        this.scoreTotal = average(feasibility, differentiation, financial);
+    }
+
+    private static double average(int feasibility, int differentiation, int financial) {
+        return (feasibility + differentiation + financial) / 3.0;
+    }
+}

--- a/src/main/java/or/hyu/ssd/domain/document/repository/EvaluatorReviewRepository.java
+++ b/src/main/java/or/hyu/ssd/domain/document/repository/EvaluatorReviewRepository.java
@@ -1,0 +1,15 @@
+package or.hyu.ssd.domain.document.repository;
+
+import or.hyu.ssd.domain.document.entity.Document;
+import or.hyu.ssd.domain.document.entity.EvaluatorReview;
+import or.hyu.ssd.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface EvaluatorReviewRepository extends JpaRepository<EvaluatorReview, Long> {
+    Optional<EvaluatorReview> findByDocumentAndReviewer(Document document, Member reviewer);
+    List<EvaluatorReview> findAllByDocument(Document document);
+    boolean existsByDocumentAndReviewer(Document document, Member reviewer);
+}

--- a/src/main/java/or/hyu/ssd/domain/document/service/EvaluatorReviewService.java
+++ b/src/main/java/or/hyu/ssd/domain/document/service/EvaluatorReviewService.java
@@ -1,0 +1,151 @@
+package or.hyu.ssd.domain.document.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import or.hyu.ssd.domain.document.controller.dto.EvaluatorReviewItemResponse;
+import or.hyu.ssd.domain.document.controller.dto.EvaluatorReviewRequest;
+import or.hyu.ssd.domain.document.controller.dto.EvaluatorReviewResponse;
+import or.hyu.ssd.domain.document.controller.dto.EvaluatorReviewSummaryResponse;
+import or.hyu.ssd.domain.document.entity.Document;
+import or.hyu.ssd.domain.document.entity.EvaluatorReview;
+import or.hyu.ssd.domain.document.repository.DocumentRepository;
+import or.hyu.ssd.domain.document.repository.EvaluatorReviewRepository;
+import or.hyu.ssd.domain.member.entity.Member;
+import or.hyu.ssd.domain.member.service.CustomUserDetails;
+import or.hyu.ssd.global.api.ErrorCode;
+import or.hyu.ssd.global.api.handler.UserExceptionHandler;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class EvaluatorReviewService {
+
+    private final EvaluatorReviewRepository evaluatorReviewRepository;
+    private final DocumentRepository documentRepository;
+
+    /**
+     * 리뷰 저장/수정 + 전체 평균 계산
+     */
+    public EvaluatorReviewResponse submit(Long documentId, CustomUserDetails user, EvaluatorReviewRequest request) {
+        Document doc = getDocument(documentId);
+        Member reviewer = getReviewer(user);
+
+        // 세가지 항목에 대한 점수를 가져옵니다
+        int feasibility = request.feasibility();
+        int differentiation = request.differentiation();
+        int financial = request.financial();
+
+        // 점수가 예상 범위 내에 존재하는지 검증합니다
+        validateScore(feasibility);
+        validateScore(differentiation);
+        validateScore(financial);
+
+        // 기존의 평가가 존재하면 업데이트, 처음이라면 생성합니다
+        Optional<EvaluatorReview> existing = evaluatorReviewRepository.findByDocumentAndReviewer(doc, reviewer);
+        EvaluatorReview saved = existing
+                .map(r -> updateReview(r, feasibility, differentiation, financial, request.comment()))
+                .orElseGet(() -> createReview(doc, reviewer, feasibility, differentiation, financial, request.comment()));
+
+        evaluatorReviewRepository.save(saved);
+
+        // 문서에 대한 모든 리뷰를 가져와서 모든 리뷰에 대한 평균을 계산합니다
+        List<EvaluatorReview> reviews = evaluatorReviewRepository.findAllByDocument(doc);
+        applyAverages(doc, reviews);
+
+        List<EvaluatorReviewItemResponse> reviewResponses = reviews.stream()
+                .map(EvaluatorReviewItemResponse::of)
+                .collect(Collectors.toList());
+        EvaluatorReviewSummaryResponse summary = toSummary(doc, reviews.size());
+
+        return EvaluatorReviewResponse.of(summary, reviewResponses);
+    }
+
+    /**
+     * 리뷰 목록 + 평균 조회
+     */
+    @Transactional(readOnly = true)
+    public EvaluatorReviewResponse get(Long documentId, CustomUserDetails user) {
+        Document doc = getDocument(documentId);
+        ensureReadable(doc, user);
+
+        List<EvaluatorReview> reviews = evaluatorReviewRepository.findAllByDocument(doc);
+        List<EvaluatorReviewItemResponse> reviewResponses = reviews.stream()
+                .map(EvaluatorReviewItemResponse::of)
+                .collect(Collectors.toList());
+        EvaluatorReviewSummaryResponse summary = toSummary(doc, reviews.size());
+
+        return EvaluatorReviewResponse.of(summary, reviewResponses);
+    }
+
+    private EvaluatorReview createReview(Document doc, Member reviewer, int feasibility, int differentiation, int financial, String comment) {
+        return EvaluatorReview.of(feasibility, differentiation, financial, comment, doc, reviewer);
+    }
+
+    private EvaluatorReview updateReview(EvaluatorReview review, int feasibility, int differentiation, int financial, String comment) {
+        review.updateScores(feasibility, differentiation, financial, comment);
+        return review;
+    }
+
+    /**
+     * 하나의 문서에 대해서 평균값을 계산하는 헬퍼 메서드입니다
+     * */
+    private void applyAverages(Document doc, List<EvaluatorReview> reviews) {
+        if (reviews.isEmpty()) {
+            doc.updateReviewSummary(null, null, null, null, 0);
+            return;
+        }
+
+        double feasibilityAvg = reviews.stream().mapToInt(EvaluatorReview::getScoreFeasibility).average().orElse(0);
+        double differentiationAvg = reviews.stream().mapToInt(EvaluatorReview::getScoreDifferentiation).average().orElse(0);
+        double financialAvg = reviews.stream().mapToInt(EvaluatorReview::getScoreFinancial).average().orElse(0);
+        double totalAvg = (feasibilityAvg + differentiationAvg + financialAvg) / 3.0;
+
+        doc.updateReviewSummary(feasibilityAvg, differentiationAvg, financialAvg, totalAvg, reviews.size());
+    }
+
+    private EvaluatorReviewSummaryResponse toSummary(Document doc, int reviewCount) {
+        double feasibility = doc.getReviewFeasibilityAvg() != null ? doc.getReviewFeasibilityAvg() : 0.0;
+        double differentiation = doc.getReviewDifferentiationAvg() != null ? doc.getReviewDifferentiationAvg() : 0.0;
+        double financial = doc.getReviewFinancialAvg() != null ? doc.getReviewFinancialAvg() : 0.0;
+        double total = doc.getReviewTotalAvg() != null ? doc.getReviewTotalAvg() : 0.0;
+        int count = doc.getReviewCount() != null ? doc.getReviewCount() : reviewCount;
+        return EvaluatorReviewSummaryResponse.of(doc.getId(), feasibility, differentiation, financial, total, count);
+    }
+
+    private void validateScore(int score) {
+        if (score < 0 || score > 100) {
+            throw new UserExceptionHandler(ErrorCode.REVIEW_INVALID_SCORE);
+        }
+    }
+
+    private Document getDocument(Long documentId) {
+        return documentRepository.findById(documentId)
+                .orElseThrow(() -> new UserExceptionHandler(ErrorCode.DOCUMENT_NOT_FOUND));
+    }
+
+    private Member getReviewer(CustomUserDetails user) {
+        if (user == null || user.getMember() == null) {
+            throw new UserExceptionHandler(ErrorCode.MEMBER_NOT_FOUND);
+        }
+        return user.getMember();
+    }
+
+    private void ensureReadable(Document doc, CustomUserDetails user) {
+        if (user == null || user.getMember() == null) {
+            throw new UserExceptionHandler(ErrorCode.MEMBER_NOT_FOUND);
+        }
+        Member member = user.getMember();
+        boolean isOwner = doc.getMember() != null && doc.getMember().getId().equals(member.getId());
+        boolean hasReview = evaluatorReviewRepository.existsByDocumentAndReviewer(doc, member);
+        if (!isOwner && !hasReview) {
+            throw new UserExceptionHandler(ErrorCode.DOCUMENT_FORBIDDEN);
+        }
+    }
+}

--- a/src/main/java/or/hyu/ssd/global/api/ErrorCode.java
+++ b/src/main/java/or/hyu/ssd/global/api/ErrorCode.java
@@ -32,6 +32,9 @@ public enum ErrorCode {
     CHECKLIST_CONFLICT(HttpStatus.CONFLICT, "CHK40901", "체크리스트가 동시에 수정되었습니다. 다시 시도해 주세요"),
     EVALUATOR_CHECKLIST_PARSE_ERROR(HttpStatus.BAD_REQUEST, "CHK40002", "평가자 체크리스트 응답 파싱에 실패했습니다"),
 
+    // 평가자 리뷰 예외
+    REVIEW_INVALID_SCORE(HttpStatus.BAD_REQUEST, "REV40001", "리뷰 점수는 0~100 범위여야 합니다"),
+
     // 요청/라우팅 예외
     REQUEST_API_NOT_FOUND(HttpStatus.NOT_FOUND, "REQ40401", "요청하신 API를 찾지 못했습니다"),
     REQUEST_METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "REQ40501", "지원하지 않는 HTTP 메서드입니다"),


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #32 


<br><br>

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

평가자 리뷰 생성 및 조회 API를 구현했습니다.

리뷰 저장 알고리즘은 다음과 같습니다.

```

1. 리뷰는 하나의 문서에 여러명의 평가자가 등록 할 수 있음
2. 리뷰의 항목은 총 세가지이며, 리뷰 항목은 고정되어 있음
    1. 사업타당성
    2. 사업차별성
    3. 재무적정성
3. 리뷰를 평가하고 사용자별로 세개의 리뷰에 대한 평균을 계산하여 저장함
    1. max 100점
4. 모든 사용자의 평균 리뷰를 저장해야함
    1. 각 평가 항목에 대한 모든 사용자의 점수를 평균으로 구함
    2. 그리고 전체 항목에 대한 평균을 구해서 전체 평가자의 총점을 저장
5. 리뷰는 점수이외에 글을 포함할 수 있음


```

<br><br>

## 🙏 Details

<!-- 이번 PR에서 구현한 내용 중 포인트가 되는 부분을 자세하게 적어주세요 -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 평가자 리뷰 기능 추가: 사용자가 문서에 대해 평가 점수(타당성, 차별성, 재정)와 의견을 제출할 수 있습니다.
  * 리뷰 조회 기능: 제출된 리뷰를 조회하고 평가 점수의 평균값을 확인할 수 있습니다.

* **Chores**
  * 리뷰 점수 유효성 검사 규칙 추가 (0-100 범위).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->