### PR TITLE
[CHORE] 문서 메타데이터를 받을 수 있도록 CRUD 수정

### DIFF
--- a/src/main/java/or/hyu/ssd/domain/document/controller/DocumentController.java
+++ b/src/main/java/or/hyu/ssd/domain/document/controller/DocumentController.java
@@ -44,7 +44,7 @@ public class DocumentController {
                     - Authorization: Bearer {accessToken}
 
                     ### 요청 본문
-                    - title (string, required): 공백 불가 제목
+                    - title (string, optional): 제목. 없으면 text/paragraphs 첫 항목으로 자동 생성
                     - text (string, required): 공백 불가 본문. 줄바꿈은 \\n 으로 이스케이프
                     - paragraphs (array, optional): 문단 메타데이터 배열
                     - path (string, optional): 폴더 경로 (예: team/project)

--- a/src/main/java/or/hyu/ssd/domain/document/controller/DocumentController.java
+++ b/src/main/java/or/hyu/ssd/domain/document/controller/DocumentController.java
@@ -45,7 +45,8 @@ public class DocumentController {
 
                     ### 요청 본문
                     - title (string, required): 공백 불가 제목
-                    - content (string, required): 공백 불가 본문. 줄바꿈은 \\n 으로 이스케이프
+                    - text (string, required): 공백 불가 본문. 줄바꿈은 \\n 으로 이스케이프
+                    - paragraphs (array, optional): 문단 메타데이터 배열
                     - path (string, optional): 폴더 경로 (예: team/project)
 
                     ### 응답
@@ -81,11 +82,12 @@ public class DocumentController {
                     - Path: /api/v1/documents/{id}
                     - Body(JSON, optional)
                       - title (string): 새 제목
-                      - content (string): 새 본문
+                      - text (string): 새 본문
                       - summary (string): 요약 본문
                       - details (string): 상세 요약
                       - path (string): 폴더 경로 (예: team/project)
                       - bookmark (boolean): 즐겨찾기 여부
+                      - paragraphs (array): 문단 메타데이터 배열
 
                     ### 응답
                     - 200 OK
@@ -158,7 +160,7 @@ public class DocumentController {
                     ### 응답
                     - 200 OK
                     - data:
-                      - id, title, content, summary, details, path, bookmark
+                      - id, title, text, paragraphs, summary, details, path, bookmark
                       - authorId, authorName
 
                     ### 오류

--- a/src/main/java/or/hyu/ssd/domain/document/controller/dto/CreateDocumentRequest.java
+++ b/src/main/java/or/hyu/ssd/domain/document/controller/dto/CreateDocumentRequest.java
@@ -1,11 +1,13 @@
 package or.hyu.ssd.domain.document.controller.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import java.util.List;
 
 public record CreateDocumentRequest(
         @NotBlank(message = "제목은 필수입니다")
         String title,
         @NotBlank(message = "내용은 필수입니다")
-        String content,
+        String text,
+        List<DocumentParagraphDto> paragraphs,
         String path
 ) {}

--- a/src/main/java/or/hyu/ssd/domain/document/controller/dto/CreateDocumentRequest.java
+++ b/src/main/java/or/hyu/ssd/domain/document/controller/dto/CreateDocumentRequest.java
@@ -4,7 +4,6 @@ import jakarta.validation.constraints.NotBlank;
 import java.util.List;
 
 public record CreateDocumentRequest(
-        @NotBlank(message = "제목은 필수입니다")
         String title,
         @NotBlank(message = "내용은 필수입니다")
         String text,

--- a/src/main/java/or/hyu/ssd/domain/document/controller/dto/DocumentParagraphDto.java
+++ b/src/main/java/or/hyu/ssd/domain/document/controller/dto/DocumentParagraphDto.java
@@ -1,0 +1,8 @@
+package or.hyu.ssd.domain.document.controller.dto;
+
+public record DocumentParagraphDto(
+        String content,
+        String role,
+        int pageNumber,
+        int blockId
+) {}

--- a/src/main/java/or/hyu/ssd/domain/document/controller/dto/GetDocumentResponse.java
+++ b/src/main/java/or/hyu/ssd/domain/document/controller/dto/GetDocumentResponse.java
@@ -1,12 +1,13 @@
 package or.hyu.ssd.domain.document.controller.dto;
 
 import or.hyu.ssd.domain.document.entity.Document;
-import java.time.LocalDateTime;
+import java.util.List;
 
 public record GetDocumentResponse(
         Long id,
         String title,
-        String content,
+        String text,
+        List<DocumentParagraphDto> paragraphs,
         String summary,
         String details,
         String path,
@@ -14,13 +15,14 @@ public record GetDocumentResponse(
         Long authorId,
         String authorName
 ) {
-    public static GetDocumentResponse of(Document doc) {
+    public static GetDocumentResponse of(Document doc, List<DocumentParagraphDto> paragraphs) {
         Long authorId = doc.getMember() != null ? doc.getMember().getId() : null;
         String authorName = doc.getMember() != null ? doc.getMember().getName() : null;
         return new GetDocumentResponse(
                 doc.getId(),
                 doc.getTitle(),
                 doc.getContent(),
+                paragraphs,
                 doc.getSummary(),
                 doc.getDetails(),
                 doc.getPath(),

--- a/src/main/java/or/hyu/ssd/domain/document/controller/dto/UpdateDocumentRequest.java
+++ b/src/main/java/or/hyu/ssd/domain/document/controller/dto/UpdateDocumentRequest.java
@@ -1,10 +1,13 @@
 package or.hyu.ssd.domain.document.controller.dto;
 
+import java.util.List;
+
 public record UpdateDocumentRequest(
         String title,
-        String content,
+        String text,
         String summary,
         String details,
         String path,
-        Boolean bookmark
+        Boolean bookmark,
+        List<DocumentParagraphDto> paragraphs
 ) {}

--- a/src/main/java/or/hyu/ssd/domain/document/entity/Document.java
+++ b/src/main/java/or/hyu/ssd/domain/document/entity/Document.java
@@ -19,28 +19,28 @@ public class Document extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Comment("사업계획서 제목")
+    @Comment("사업계획서 제목 (입력: title)")
     @Column(name = "title", nullable = false)
     private String title;
 
-    @Comment("사업계획서 본문")
+    @Comment("사업계획서 본문 (입력: text)")
     @Column(name = "content", nullable = false, columnDefinition = "TEXT")
     private String content;
 
-    @Comment("문서 경로(폴더 경로)")
+    @Comment("문서 경로(폴더 경로) (입력: path)")
     @Column(name = "path", nullable = false, length = 512)
     @ColumnDefault("''")
     private String path;
 
-    @Comment("사업계획서 즐겨찾기 여부")
+    @Comment("사업계획서 즐겨찾기 여부 (입력: bookmark)")
     @Column(name = "bookmark", nullable = false)
     private boolean bookmark;
 
-    @Comment("ai가 생성한 사업계획서 세 줄 요약")
+    @Comment("ai가 생성한 사업계획서 세 줄 요약 (입력: summary)")
     @Column(name = "summary", nullable = true, columnDefinition = "TEXT")
     private String summary;
 
-    @Comment("ai가 생성한 사업계획서 상세 요약")
+    @Comment("ai가 생성한 사업계획서 상세 요약 (입력: details)")
     @Column(name = "details", nullable = true, columnDefinition = "TEXT")
     private String details;
 

--- a/src/main/java/or/hyu/ssd/domain/document/entity/Document.java
+++ b/src/main/java/or/hyu/ssd/domain/document/entity/Document.java
@@ -19,7 +19,7 @@ public class Document extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Comment("사업계획서 제목 (입력: title)")
+    @Comment("사업계획서 제목 (입력: title, 없으면 text/paragraphs에서 생성)")
     @Column(name = "title", nullable = false)
     private String title;
 

--- a/src/main/java/or/hyu/ssd/domain/document/entity/DocumentParagraph.java
+++ b/src/main/java/or/hyu/ssd/domain/document/entity/DocumentParagraph.java
@@ -1,0 +1,60 @@
+package or.hyu.ssd.domain.document.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import or.hyu.ssd.global.entity.BaseEntity;
+import org.hibernate.annotations.Comment;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+@Builder
+@Table(
+        name = "document_paragraphs",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_document_paragraph_doc_block", columnNames = {"document_id", "block_id"})
+        },
+        indexes = {
+                @Index(name = "idx_document_paragraph_document_id", columnList = "document_id")
+        }
+)
+public class DocumentParagraph extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Comment("문단 내용 (입력: paragraphs[].content)")
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Comment("문단 역할(입력: paragraphs[].role)")
+    @Column(name = "role", length = 16)
+    private String role;
+
+    @Comment("문단 페이지 번호 (입력: paragraphs[].pageNumber)")
+    @Column(name = "page_number", nullable = false)
+    private int pageNumber;
+
+    @Comment("문단 블록 ID (입력: paragraphs[].blockId)")
+    @Column(name = "block_id", nullable = false)
+    private int blockId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "document_id", nullable = false)
+    private Document document;
+
+    @Version
+    private Long version;
+
+    public static DocumentParagraph of(String content, String role, int pageNumber, int blockId, Document document) {
+        return DocumentParagraph.builder()
+                .content(content)
+                .role(role)
+                .pageNumber(pageNumber)
+                .blockId(blockId)
+                .document(document)
+                .build();
+    }
+}

--- a/src/main/java/or/hyu/ssd/domain/document/repository/DocumentParagraphRepository.java
+++ b/src/main/java/or/hyu/ssd/domain/document/repository/DocumentParagraphRepository.java
@@ -1,0 +1,12 @@
+package or.hyu.ssd.domain.document.repository;
+
+import or.hyu.ssd.domain.document.entity.Document;
+import or.hyu.ssd.domain.document.entity.DocumentParagraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface DocumentParagraphRepository extends JpaRepository<DocumentParagraph, Long> {
+    List<DocumentParagraph> findAllByDocumentOrderByPageNumberAscBlockIdAscIdAsc(Document document);
+    void deleteAllByDocument(Document document);
+}

--- a/src/main/java/or/hyu/ssd/domain/document/service/DocumentService.java
+++ b/src/main/java/or/hyu/ssd/domain/document/service/DocumentService.java
@@ -3,12 +3,15 @@ import lombok.RequiredArgsConstructor;
 import or.hyu.ssd.domain.document.controller.dto.CreateDocumentRequest;
 import or.hyu.ssd.domain.document.controller.dto.CreateDocumentResponse;
 import or.hyu.ssd.domain.document.controller.dto.DocumentListItemResponse;
+import or.hyu.ssd.domain.document.controller.dto.DocumentParagraphDto;
 import or.hyu.ssd.domain.document.controller.dto.GetDocumentResponse;
 import or.hyu.ssd.domain.document.controller.dto.UpdateDocumentRequest;
 import or.hyu.ssd.domain.document.controller.dto.UpdateDocumentResponse;
 import or.hyu.ssd.domain.document.controller.dto.DocumentBookmarkResponse;
 import or.hyu.ssd.domain.document.entity.Document;
+import or.hyu.ssd.domain.document.entity.DocumentParagraph;
 import or.hyu.ssd.domain.document.repository.CheckListRepository;
+import or.hyu.ssd.domain.document.repository.DocumentParagraphRepository;
 import or.hyu.ssd.domain.document.repository.EvaluatorCheckListRepository;
 import or.hyu.ssd.domain.document.repository.DocumentRepository;
 import or.hyu.ssd.domain.document.service.support.DocumentSort;
@@ -31,14 +34,16 @@ public class DocumentService {
     private final DocumentRepository documentRepository;
     private final CheckListRepository checkListRepository;
     private final EvaluatorCheckListRepository evaluatorCheckListRepository;
+    private final DocumentParagraphRepository documentParagraphRepository;
     private final OptimisticRetryExecutor optimisticRetryExecutor;
 
     public CreateDocumentResponse createDocument(CustomUserDetails user, CreateDocumentRequest req) {
 
         String normalizedPath = normalizePath(req.path());
-        Document doc = Document.of(req.title(), req.content(), normalizedPath, false, user.getMember());
+        Document doc = Document.of(req.title(), req.text(), normalizedPath, false, user.getMember());
 
         Document saved = documentRepository.save(doc);
+        saveParagraphsIfPresent(saved, req.paragraphs());
         return CreateDocumentResponse.of(saved.getId());
     }
 
@@ -53,7 +58,11 @@ public class DocumentService {
         }
 
         String normalizedPath = normalizePathOrNull(req.path());
-        doc.updateIfPresent(req.title(), req.content(), req.summary(), req.details(), normalizedPath, req.bookmark());
+        doc.updateIfPresent(req.title(), req.text(), req.summary(), req.details(), normalizedPath, req.bookmark());
+        if (req.paragraphs() != null) {
+            documentParagraphRepository.deleteAllByDocument(doc);
+            saveParagraphsIfPresent(doc, req.paragraphs());
+        }
 
         return UpdateDocumentResponse.of(doc.getId());
     }
@@ -70,6 +79,7 @@ public class DocumentService {
 
         checkListRepository.deleteAllByDocument(doc);
         evaluatorCheckListRepository.deleteAllByDocument(doc);
+        documentParagraphRepository.deleteAllByDocument(doc);
         documentRepository.delete(doc);
     }
 
@@ -84,7 +94,8 @@ public class DocumentService {
             throw new UserExceptionHandler(ErrorCode.DOCUMENT_FORBIDDEN);
         }
 
-        return GetDocumentResponse.of(doc);
+        List<DocumentParagraphDto> paragraphs = fetchParagraphs(doc);
+        return GetDocumentResponse.of(doc, paragraphs);
     }
 
     @Transactional(readOnly = true)
@@ -174,5 +185,21 @@ public class DocumentService {
             return "/";
         }
         return "/" + path;
+    }
+
+    private void saveParagraphsIfPresent(Document doc, List<DocumentParagraphDto> paragraphs) {
+        if (paragraphs == null || paragraphs.isEmpty()) {
+            return;
+        }
+        List<DocumentParagraph> entities = paragraphs.stream()
+                .map(p -> DocumentParagraph.of(p.content(), p.role(), p.pageNumber(), p.blockId(), doc))
+                .collect(Collectors.toList());
+        documentParagraphRepository.saveAll(entities);
+    }
+
+    private List<DocumentParagraphDto> fetchParagraphs(Document doc) {
+        return documentParagraphRepository.findAllByDocumentOrderByPageNumberAscBlockIdAscIdAsc(doc).stream()
+                .map(p -> new DocumentParagraphDto(p.getContent(), p.getRole(), p.getPageNumber(), p.getBlockId()))
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #47 


<br><br>

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

문서의 메타데이터를 저장 할 수 있도록 테이블을 추가하였습니다.
새롭게 추가된 테이블은 다음과 같습니다.

```

package or.hyu.ssd.domain.document.entity;

import jakarta.persistence.*;
import lombok.*;
import or.hyu.ssd.global.entity.BaseEntity;
import org.hibernate.annotations.Comment;

@Entity
@NoArgsConstructor(access = AccessLevel.PROTECTED)
@AllArgsConstructor
@Getter
@Builder
@Table(
        name = "document_paragraphs",
        uniqueConstraints = {
                @UniqueConstraint(name = "uk_document_paragraph_doc_block", columnNames = {"document_id", "block_id"})
        },
        indexes = {
                @Index(name = "idx_document_paragraph_document_id", columnList = "document_id")
        }
)
public class DocumentParagraph extends BaseEntity {

    @Id
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    private Long id;

    @Comment("문단 내용 (입력: paragraphs[].content)")
    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
    private String content;

    @Comment("문단 역할(입력: paragraphs[].role)")
    @Column(name = "role", length = 16)
    private String role;

    @Comment("문단 페이지 번호 (입력: paragraphs[].pageNumber)")
    @Column(name = "page_number", nullable = false)
    private int pageNumber;

    @Comment("문단 블록 ID (입력: paragraphs[].blockId)")
    @Column(name = "block_id", nullable = false)
    private int blockId;

    @ManyToOne(fetch = FetchType.LAZY)
    @JoinColumn(name = "document_id", nullable = false)
    private Document document;

    @Version
    private Long version;

    public static DocumentParagraph of(String content, String role, int pageNumber, int blockId, Document document) {
        return DocumentParagraph.builder()
                .content(content)
                .role(role)
                .pageNumber(pageNumber)
                .blockId(blockId)
                .document(document)
                .build();
    }
}


```


주석을 활용한 조회 기능의 호출이 잦을 것으로 예상하여 document_id와 block_id를 활용한 복합인덱스를 함께 구현하였습니다.


<br><br>

## 🙏 Details

<!-- 이번 PR에서 구현한 내용 중 포인트가 되는 부분을 자세하게 적어주세요 -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 문서에 단락 구조 저장 및 관리 기능 추가
  * 문서 제목이 제공되지 않을 때 자동으로 생성되는 기능 추가

* **API 변경**
  * 문서 생성 시 제목을 선택 사항으로 변경
  * 문서 요청/응답 형식에 단락 배열 추가
  * 콘텐츠 필드명을 텍스트로 통일

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->