### PR TITLE
[CHORE] blockId 생성 로직 구현

### DIFF
--- a/src/main/java/or/hyu/ssd/domain/document/controller/DocumentController.java
+++ b/src/main/java/or/hyu/ssd/domain/document/controller/DocumentController.java
@@ -47,7 +47,7 @@ public class DocumentController {
                     ### 요청 본문
                     - title (string, optional): 제목. 없으면 text/paragraphs 첫 항목으로 자동 생성
                     - text (string, required): 공백 불가 본문. 줄바꿈은 \\n 으로 이스케이프
-                    - paragraphs (array, optional): 문단 메타데이터 배열
+                    - paragraphs (array, optional): 문단 메타데이터 배열 (blockId는 서버가 1..n으로 자동 부여)
                     - path (string, optional): 폴더 경로 (예: team/project)
 
                     ### 응답
@@ -88,7 +88,7 @@ public class DocumentController {
                       - details (string): 상세 요약
                       - path (string): 폴더 경로 (예: team/project)
                       - bookmark (boolean): 즐겨찾기 여부
-                      - paragraphs (array): 문단 메타데이터 배열
+                      - paragraphs (array): 문단 메타데이터 배열 (blockId는 서버가 1..n으로 자동 부여)
 
                     ### 응답
                     - 200 OK

--- a/src/main/java/or/hyu/ssd/domain/document/controller/dto/DocumentParagraphDto.java
+++ b/src/main/java/or/hyu/ssd/domain/document/controller/dto/DocumentParagraphDto.java
@@ -4,5 +4,5 @@ public record DocumentParagraphDto(
         String content,
         String role,
         int pageNumber,
-        int blockId
+        Integer blockId
 ) {}

--- a/src/main/java/or/hyu/ssd/domain/document/entity/DocumentParagraph.java
+++ b/src/main/java/or/hyu/ssd/domain/document/entity/DocumentParagraph.java
@@ -19,6 +19,7 @@ import org.hibernate.annotations.Comment;
                 @Index(name = "idx_document_paragraph_document_id", columnList = "document_id")
         }
 )
+@Comment("Document의 block을 저장하는 엔티티입니다")
 public class DocumentParagraph extends BaseEntity {
 
     @Id

--- a/src/main/java/or/hyu/ssd/domain/document/service/DocumentService.java
+++ b/src/main/java/or/hyu/ssd/domain/document/service/DocumentService.java
@@ -26,6 +26,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import or.hyu.ssd.global.util.OptimisticRetryExecutor;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -257,9 +258,13 @@ public class DocumentService {
         if (paragraphs == null || paragraphs.isEmpty()) {
             return;
         }
-        List<DocumentParagraph> entities = paragraphs.stream()
-                .map(p -> DocumentParagraph.of(p.content(), p.role(), p.pageNumber(), p.blockId(), doc))
-                .collect(Collectors.toList());
+        List<DocumentParagraph> entities = new ArrayList<>(paragraphs.size());
+
+        // blockId를 서버에서 임의로 증가시킵니다
+        int blockId = 1;
+        for (DocumentParagraphDto p : paragraphs) {
+            entities.add(DocumentParagraph.of(p.content(), p.role(), p.pageNumber(), blockId++, doc));
+        }
         documentParagraphRepository.saveAll(entities);
     }
 


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #53 


<br><br>

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

전에는 block_id를 입력 body로 받던 로직에서, 내용만 받아서 block_id를 생성하는 로직으로 수정하였습니다.

또한 blockId 필드를 추가하여 문서 별로 고유한 blockId를 지닐 수 있도록 로직을 수정하였습니다.


<br><br>

## 🙏 Details

<!-- 이번 PR에서 구현한 내용 중 포인트가 되는 부분을 자세하게 적어주세요 -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **버그 수정**
  * 문단 추가 시 blockId가 이제 서버에서 자동으로 순차 할당됩니다.

* **문서**
  * 문서 생성/수정 API 명세에서 blockId의 자동 할당 동작을 명시했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->