### PR TITLE
[FEAT] 주석 CRUD API 구현

### DIFF
--- a/src/main/java/or/hyu/ssd/domain/document/controller/DocumentCommentController.java
+++ b/src/main/java/or/hyu/ssd/domain/document/controller/DocumentCommentController.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import or.hyu.ssd.domain.document.controller.dto.DocumentCommentItemResponse;
 import or.hyu.ssd.domain.document.controller.dto.DocumentCommentRequest;
 import or.hyu.ssd.domain.document.controller.dto.DocumentCommentResponse;
+import or.hyu.ssd.domain.document.controller.dto.DocumentCommentUpdateRequest;
 import or.hyu.ssd.domain.document.service.DocumentCommentService;
 import or.hyu.ssd.domain.member.service.CustomUserDetails;
 import or.hyu.ssd.global.api.ApiResponse;
@@ -14,6 +15,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -62,6 +64,40 @@ public class DocumentCommentController {
     ) {
         DocumentCommentResponse dto = documentCommentService.create(documentId, user, request);
         return ResponseEntity.ok(ApiResponse.ok(dto, "주석이 저장되었습니다"));
+    }
+
+    @PatchMapping("/v1/comments/{id}")
+    @Operation(
+            summary = "주석 수정",
+            description = """
+                    ### 개요
+                    - 주석 코멘트 내용을 수정합니다.
+
+                    ### 인증
+                    - Authorization: Bearer {accessToken}
+
+                    ### 요청
+                    - Path: /api/v1/comments/{id}
+                    - Body(JSON)
+                      - comment (string, required): 수정할 주석 코멘트 본문
+
+                    ### 응답
+                    - 200 OK
+                    - data.id: 수정된 주석 ID
+
+                    ### 오류
+                    - CMT40401: 주석을 찾지 못했습니다
+                    - CMT40301: 해당 주석을 수정할 권한이 없습니다
+                    - MEMBER40101: 회원을 찾지 못했습니다
+                    """
+    )
+    public ResponseEntity<ApiResponse<DocumentCommentResponse>> update(
+            @PathVariable Long id,
+            @Valid @RequestBody DocumentCommentUpdateRequest request,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        DocumentCommentResponse dto = documentCommentService.update(id, user, request);
+        return ResponseEntity.ok(ApiResponse.ok(dto, "주석이 수정되었습니다"));
     }
 
     @GetMapping("/v1/documents/{documentId}/comments")

--- a/src/main/java/or/hyu/ssd/domain/document/controller/DocumentCommentController.java
+++ b/src/main/java/or/hyu/ssd/domain/document/controller/DocumentCommentController.java
@@ -1,0 +1,62 @@
+package or.hyu.ssd.domain.document.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import or.hyu.ssd.domain.document.controller.dto.DocumentCommentRequest;
+import or.hyu.ssd.domain.document.controller.dto.DocumentCommentResponse;
+import or.hyu.ssd.domain.document.service.DocumentCommentService;
+import or.hyu.ssd.domain.member.service.CustomUserDetails;
+import or.hyu.ssd.global.api.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+@Tag(name = "주석 API", description = "문단 주석 생성/조회")
+public class DocumentCommentController {
+
+    private final DocumentCommentService documentCommentService;
+
+    @PostMapping("/v1/documents/{documentId}/comments")
+    @Operation(
+            summary = "주석 생성",
+            description = """
+                    ### 개요
+                    - 문서의 특정 블록에 주석 코멘트를 저장합니다.
+
+                    ### 인증
+                    - Authorization: Bearer {accessToken} (문서 작성자만)
+
+                    ### 요청
+                    - Path: /api/v1/documents/{documentId}/comments
+                    - Body(JSON)
+                      - blockId (int, required): 주석 대상 블록 ID
+                      - comment (string, required): 주석 코멘트 본문
+
+                    ### 응답
+                    - 200 OK
+                    - data.id: 생성된 주석 ID
+
+                    ### 오류
+                    - DOC40401: 문서를 찾을 수 없음
+                    - DOC40301: 문서 소유자가 아님
+                    - DOC40402: 문서 블록을 찾을 수 없음
+                    """
+    )
+    public ResponseEntity<ApiResponse<DocumentCommentResponse>> create(
+            @PathVariable Long documentId,
+            @Valid @RequestBody DocumentCommentRequest request,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        DocumentCommentResponse dto = documentCommentService.create(documentId, user, request);
+        return ResponseEntity.ok(ApiResponse.ok(dto, "주석이 저장되었습니다"));
+    }
+}

--- a/src/main/java/or/hyu/ssd/domain/document/controller/DocumentCommentController.java
+++ b/src/main/java/or/hyu/ssd/domain/document/controller/DocumentCommentController.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.DeleteMapping;
 
 import java.util.List;
 
@@ -98,6 +99,37 @@ public class DocumentCommentController {
     ) {
         DocumentCommentResponse dto = documentCommentService.update(id, user, request);
         return ResponseEntity.ok(ApiResponse.ok(dto, "주석이 수정되었습니다"));
+    }
+
+    @DeleteMapping("/v1/comments/{id}")
+    @Operation(
+            summary = "주석 삭제",
+            description = """
+                    ### 개요
+                    - 주석을 삭제합니다.
+
+                    ### 인증
+                    - Authorization: Bearer {accessToken}
+
+                    ### 요청
+                    - Path: /api/v1/comments/{id}
+
+                    ### 응답
+                    - 200 OK
+                    - data: "주석이 삭제되었습니다"
+
+                    ### 오류
+                    - CMT40401: 주석을 찾지 못했습니다
+                    - CMT40301: 해당 주석을 수정할 권한이 없습니다
+                    - MEMBER40101: 회원을 찾지 못했습니다
+                    """
+    )
+    public ResponseEntity<ApiResponse<String>> delete(
+            @PathVariable Long id,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        documentCommentService.delete(id, user);
+        return ResponseEntity.ok(ApiResponse.ok("주석이 삭제되었습니다"));
     }
 
     @GetMapping("/v1/documents/{documentId}/comments")

--- a/src/main/java/or/hyu/ssd/domain/document/controller/DocumentCommentController.java
+++ b/src/main/java/or/hyu/ssd/domain/document/controller/DocumentCommentController.java
@@ -33,7 +33,7 @@ public class DocumentCommentController {
                     - 문서의 특정 블록에 주석 코멘트를 저장합니다.
 
                     ### 인증
-                    - Authorization: Bearer {accessToken} (문서 작성자만)
+                    - Authorization: Bearer {accessToken}
 
                     ### 요청
                     - Path: /api/v1/documents/{documentId}/comments
@@ -47,7 +47,7 @@ public class DocumentCommentController {
 
                     ### 오류
                     - DOC40401: 문서를 찾을 수 없음
-                    - DOC40301: 문서 소유자가 아님
+                    - MEMBER40101: 회원을 찾지 못했습니다
                     - DOC40402: 문서 블록을 찾을 수 없음
                     """
     )

--- a/src/main/java/or/hyu/ssd/domain/document/controller/DocumentCommentController.java
+++ b/src/main/java/or/hyu/ssd/domain/document/controller/DocumentCommentController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import or.hyu.ssd.domain.document.controller.dto.DocumentCommentItemResponse;
 import or.hyu.ssd.domain.document.controller.dto.DocumentCommentRequest;
 import or.hyu.ssd.domain.document.controller.dto.DocumentCommentResponse;
 import or.hyu.ssd.domain.document.service.DocumentCommentService;
@@ -11,11 +12,14 @@ import or.hyu.ssd.domain.member.service.CustomUserDetails;
 import or.hyu.ssd.global.api.ApiResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api")
@@ -58,5 +62,35 @@ public class DocumentCommentController {
     ) {
         DocumentCommentResponse dto = documentCommentService.create(documentId, user, request);
         return ResponseEntity.ok(ApiResponse.ok(dto, "주석이 저장되었습니다"));
+    }
+
+    @GetMapping("/v1/documents/{documentId}/comments")
+    @Operation(
+            summary = "주석 조회",
+            description = """
+                    ### 개요
+                    - 문서에 저장된 주석 목록을 조회합니다.
+
+                    ### 인증
+                    - Authorization: Bearer {accessToken}
+
+                    ### 요청
+                    - Path: /api/v1/documents/{documentId}/comments
+
+                    ### 응답
+                    - 200 OK
+                    - data[]: 주석 목록(username, email, createdAt, content, comment)
+
+                    ### 오류
+                    - DOC40401: 문서를 찾을 수 없음
+                    - MEMBER40101: 회원을 찾지 못했습니다
+                    """
+    )
+    public ResponseEntity<ApiResponse<List<DocumentCommentItemResponse>>> list(
+            @PathVariable Long documentId,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        List<DocumentCommentItemResponse> items = documentCommentService.list(documentId, user);
+        return ResponseEntity.ok(ApiResponse.ok(items, "주석이 조회되었습니다"));
     }
 }

--- a/src/main/java/or/hyu/ssd/domain/document/controller/dto/DocumentCommentItemResponse.java
+++ b/src/main/java/or/hyu/ssd/domain/document/controller/dto/DocumentCommentItemResponse.java
@@ -1,0 +1,16 @@
+package or.hyu.ssd.domain.document.controller.dto;
+
+import java.time.LocalDateTime;
+
+public record DocumentCommentItemResponse(
+        String username,
+        String email,
+        LocalDateTime createdAt,
+        String content,
+        String comment
+) {
+    public static DocumentCommentItemResponse of(String username, String email, LocalDateTime createdAt,
+                                                 String content, String comment) {
+        return new DocumentCommentItemResponse(username, email, createdAt, content, comment);
+    }
+}

--- a/src/main/java/or/hyu/ssd/domain/document/controller/dto/DocumentCommentRequest.java
+++ b/src/main/java/or/hyu/ssd/domain/document/controller/dto/DocumentCommentRequest.java
@@ -1,0 +1,10 @@
+package or.hyu.ssd.domain.document.controller.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record DocumentCommentRequest(
+        @NotNull @Min(1) Integer blockId,
+        @NotBlank String comment
+) {}

--- a/src/main/java/or/hyu/ssd/domain/document/controller/dto/DocumentCommentResponse.java
+++ b/src/main/java/or/hyu/ssd/domain/document/controller/dto/DocumentCommentResponse.java
@@ -1,0 +1,8 @@
+package or.hyu.ssd.domain.document.controller.dto;
+
+public record DocumentCommentResponse(Long id) {
+
+    public static DocumentCommentResponse of(Long id) {
+        return new DocumentCommentResponse(id);
+    }
+}

--- a/src/main/java/or/hyu/ssd/domain/document/controller/dto/DocumentCommentUpdateRequest.java
+++ b/src/main/java/or/hyu/ssd/domain/document/controller/dto/DocumentCommentUpdateRequest.java
@@ -1,0 +1,7 @@
+package or.hyu.ssd.domain.document.controller.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record DocumentCommentUpdateRequest(
+        @NotBlank String comment
+) {}

--- a/src/main/java/or/hyu/ssd/domain/document/entity/CheckList.java
+++ b/src/main/java/or/hyu/ssd/domain/document/entity/CheckList.java
@@ -19,6 +19,7 @@ import org.hibernate.annotations.Comment;
                 @Index(name = "idx_checklist_document_id", columnList = "document_id")
         }
 )
+@Comment("작성자 체크리스트")
 public class CheckList extends BaseEntity {
 
     @Id

--- a/src/main/java/or/hyu/ssd/domain/document/entity/DocumentComment.java
+++ b/src/main/java/or/hyu/ssd/domain/document/entity/DocumentComment.java
@@ -62,4 +62,8 @@ public class DocumentComment extends BaseEntity {
                 .member(member)
                 .build();
     }
+
+    public void updateComment(String comment) {
+        this.comment = comment;
+    }
 }

--- a/src/main/java/or/hyu/ssd/domain/document/entity/DocumentComment.java
+++ b/src/main/java/or/hyu/ssd/domain/document/entity/DocumentComment.java
@@ -1,0 +1,65 @@
+package or.hyu.ssd.domain.document.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import or.hyu.ssd.domain.member.entity.Member;
+import or.hyu.ssd.global.entity.BaseEntity;
+import org.hibernate.annotations.Comment;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+@Builder
+@Table(
+        name = "document_comments",
+        indexes = {
+                @Index(name = "idx_document_comment_document_id", columnList = "document_id"),
+                @Index(name = "idx_document_comment_block_id", columnList = "block_id")
+        }
+)
+@Comment("Document의 문단에 대한 주석")
+public class DocumentComment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Comment("주석 대상 블록 ID")
+    @Column(name = "block_id", nullable = false)
+    private int blockId;
+
+    @Comment("주석 코멘트 본문")
+    @Column(name = "comment", nullable = false, columnDefinition = "TEXT")
+    private String comment;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "document_id", nullable = false)
+    private Document document;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    public static DocumentComment of(int blockId, String comment, Document document, Member member) {
+        return DocumentComment.builder()
+                .blockId(blockId)
+                .comment(comment)
+                .document(document)
+                .member(member)
+                .build();
+    }
+}

--- a/src/main/java/or/hyu/ssd/domain/document/entity/DocumentLog.java
+++ b/src/main/java/or/hyu/ssd/domain/document/entity/DocumentLog.java
@@ -16,6 +16,7 @@ import org.hibernate.annotations.Comment;
                 @Index(name = "idx_document_log_document_id", columnList = "document_id")
         }
 )
+@Comment("문서 수정 기록 엔티티")
 public class DocumentLog extends BaseEntity {
 
     @Id

--- a/src/main/java/or/hyu/ssd/domain/document/entity/DocumentParagraph.java
+++ b/src/main/java/or/hyu/ssd/domain/document/entity/DocumentParagraph.java
@@ -19,7 +19,7 @@ import org.hibernate.annotations.Comment;
                 @Index(name = "idx_document_paragraph_document_id", columnList = "document_id")
         }
 )
-@Comment("Document의 block을 저장하는 엔티티입니다")
+@Comment("Document의 block을 저장하는 엔티티")
 public class DocumentParagraph extends BaseEntity {
 
     @Id

--- a/src/main/java/or/hyu/ssd/domain/document/entity/EvaluatorCheckList.java
+++ b/src/main/java/or/hyu/ssd/domain/document/entity/EvaluatorCheckList.java
@@ -19,6 +19,7 @@ import org.hibernate.annotations.Comment;
                 @Index(name = "idx_evaluator_checklist_document_id", columnList = "document_id")
         }
 )
+@Comment("평가자 체크리스트")
 public class EvaluatorCheckList extends BaseEntity {
 
     @Id

--- a/src/main/java/or/hyu/ssd/domain/document/entity/EvaluatorReview.java
+++ b/src/main/java/or/hyu/ssd/domain/document/entity/EvaluatorReview.java
@@ -21,6 +21,7 @@ import org.hibernate.annotations.Comment;
                 @Index(name = "idx_evaluator_review_member_id", columnList = "member_id")
         }
 )
+@Comment("평가자 리뷰 엔티티")
 public class EvaluatorReview extends BaseEntity {
 
     @Id

--- a/src/main/java/or/hyu/ssd/domain/document/repository/DocumentCommentRepository.java
+++ b/src/main/java/or/hyu/ssd/domain/document/repository/DocumentCommentRepository.java
@@ -1,0 +1,12 @@
+package or.hyu.ssd.domain.document.repository;
+
+import or.hyu.ssd.domain.document.entity.Document;
+import or.hyu.ssd.domain.document.entity.DocumentComment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface DocumentCommentRepository extends JpaRepository<DocumentComment, Long> {
+    List<DocumentComment> findAllByDocumentOrderByCreatedAtAsc(Document document);
+    void deleteAllByDocument(Document document);
+}

--- a/src/main/java/or/hyu/ssd/domain/document/repository/DocumentCommentRepository.java
+++ b/src/main/java/or/hyu/ssd/domain/document/repository/DocumentCommentRepository.java
@@ -2,11 +2,13 @@ package or.hyu.ssd.domain.document.repository;
 
 import or.hyu.ssd.domain.document.entity.Document;
 import or.hyu.ssd.domain.document.entity.DocumentComment;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface DocumentCommentRepository extends JpaRepository<DocumentComment, Long> {
+    @EntityGraph(attributePaths = "member")
     List<DocumentComment> findAllByDocumentOrderByCreatedAtAsc(Document document);
     void deleteAllByDocument(Document document);
 }

--- a/src/main/java/or/hyu/ssd/domain/document/repository/DocumentParagraphRepository.java
+++ b/src/main/java/or/hyu/ssd/domain/document/repository/DocumentParagraphRepository.java
@@ -5,8 +5,10 @@ import or.hyu.ssd.domain.document.entity.DocumentParagraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface DocumentParagraphRepository extends JpaRepository<DocumentParagraph, Long> {
     List<DocumentParagraph> findAllByDocumentOrderByPageNumberAscBlockIdAscIdAsc(Document document);
+    Optional<DocumentParagraph> findByDocumentAndBlockId(Document document, int blockId);
     void deleteAllByDocument(Document document);
 }

--- a/src/main/java/or/hyu/ssd/domain/document/service/DocumentCommentService.java
+++ b/src/main/java/or/hyu/ssd/domain/document/service/DocumentCommentService.java
@@ -1,0 +1,59 @@
+package or.hyu.ssd.domain.document.service;
+
+import lombok.RequiredArgsConstructor;
+import or.hyu.ssd.domain.document.controller.dto.DocumentCommentRequest;
+import or.hyu.ssd.domain.document.controller.dto.DocumentCommentResponse;
+import or.hyu.ssd.domain.document.entity.Document;
+import or.hyu.ssd.domain.document.entity.DocumentComment;
+import or.hyu.ssd.domain.document.repository.DocumentCommentRepository;
+import or.hyu.ssd.domain.document.repository.DocumentParagraphRepository;
+import or.hyu.ssd.domain.document.repository.DocumentRepository;
+import or.hyu.ssd.domain.member.service.CustomUserDetails;
+import or.hyu.ssd.global.api.ErrorCode;
+import or.hyu.ssd.global.api.handler.UserExceptionHandler;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class DocumentCommentService {
+
+    private final DocumentRepository documentRepository;
+    private final DocumentParagraphRepository documentParagraphRepository;
+    private final DocumentCommentRepository documentCommentRepository;
+
+    public DocumentCommentResponse create(Long documentId, CustomUserDetails user, DocumentCommentRequest request) {
+
+        // 식별자를 통해서 문서를 조회합니다
+        Document doc = getOwnedDocument(documentId, user);
+        int blockId = request.blockId();
+
+        // 문서와 blockId를 통해서 지정된 blockId를 조회합니다
+        ensureBlockExists(doc, blockId);
+
+        // 그걸 저장합니다
+        DocumentComment saved = documentCommentRepository.save(
+                DocumentComment.of(blockId, request.comment(), doc, user.getMember())
+        );
+        return DocumentCommentResponse.of(saved.getId());
+    }
+
+    private Document getOwnedDocument(Long documentId, CustomUserDetails user) {
+        Document doc = documentRepository.findById(documentId)
+                .orElseThrow(() -> new UserExceptionHandler(ErrorCode.DOCUMENT_NOT_FOUND));
+        if (doc.getMember() == null || user == null || user.getMember() == null) {
+            throw new UserExceptionHandler(ErrorCode.DOCUMENT_FORBIDDEN);
+        }
+        if (!doc.getMember().getId().equals(user.getMember().getId())) {
+            throw new UserExceptionHandler(ErrorCode.DOCUMENT_FORBIDDEN);
+        }
+        return doc;
+    }
+
+    private void ensureBlockExists(Document doc, int blockId) {
+        if (documentParagraphRepository.findByDocumentAndBlockId(doc, blockId).isEmpty()) {
+            throw new UserExceptionHandler(ErrorCode.DOCUMENT_PARAGRAPH_NOT_FOUND);
+        }
+    }
+}

--- a/src/main/java/or/hyu/ssd/domain/document/service/DocumentCommentService.java
+++ b/src/main/java/or/hyu/ssd/domain/document/service/DocumentCommentService.java
@@ -53,6 +53,13 @@ public class DocumentCommentService {
         return DocumentCommentResponse.of(comment.getId());
     }
 
+    public void delete(Long commentId, CustomUserDetails user) {
+        ensureAuthenticated(user);
+        DocumentComment comment = getComment(commentId);
+        ensureCommentOwner(comment, user);
+        documentCommentRepository.delete(comment);
+    }
+
     @Transactional(readOnly = true)
     public List<DocumentCommentItemResponse> list(Long documentId, CustomUserDetails user) {
 

--- a/src/main/java/or/hyu/ssd/domain/document/service/DocumentService.java
+++ b/src/main/java/or/hyu/ssd/domain/document/service/DocumentService.java
@@ -13,6 +13,7 @@ import or.hyu.ssd.domain.document.entity.Document;
 import or.hyu.ssd.domain.document.entity.DocumentLog;
 import or.hyu.ssd.domain.document.entity.DocumentParagraph;
 import or.hyu.ssd.domain.document.repository.CheckListRepository;
+import or.hyu.ssd.domain.document.repository.DocumentCommentRepository;
 import or.hyu.ssd.domain.document.repository.DocumentLogRepository;
 import or.hyu.ssd.domain.document.repository.DocumentParagraphRepository;
 import or.hyu.ssd.domain.document.repository.EvaluatorCheckListRepository;
@@ -39,6 +40,7 @@ public class DocumentService {
     private final CheckListRepository checkListRepository;
     private final EvaluatorCheckListRepository evaluatorCheckListRepository;
     private final DocumentParagraphRepository documentParagraphRepository;
+    private final DocumentCommentRepository documentCommentRepository;
     private final DocumentLogRepository documentLogRepository;
     private final OptimisticRetryExecutor optimisticRetryExecutor;
 
@@ -88,6 +90,7 @@ public class DocumentService {
         checkListRepository.deleteAllByDocument(doc);
         evaluatorCheckListRepository.deleteAllByDocument(doc);
         documentParagraphRepository.deleteAllByDocument(doc);
+        documentCommentRepository.deleteAllByDocument(doc);
         documentLogRepository.deleteAllByDocument(doc);
         documentRepository.delete(doc);
     }

--- a/src/main/java/or/hyu/ssd/global/api/ErrorCode.java
+++ b/src/main/java/or/hyu/ssd/global/api/ErrorCode.java
@@ -27,6 +27,10 @@ public enum ErrorCode {
     DOCUMENT_FORBIDDEN(HttpStatus.FORBIDDEN, "DOC40301", "해당 문서를 수정할 권한이 없습니다"),
     DOCUMENT_PARAGRAPH_NOT_FOUND(HttpStatus.NOT_FOUND, "DOC40402", "문서의 블록을 찾지 못했습니다"),
 
+    // 주석 예외
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "CMT40401", "주석을 찾지 못했습니다"),
+    COMMENT_FORBIDDEN(HttpStatus.FORBIDDEN, "CMT40301", "해당 주석을 수정할 권한이 없습니다"),
+
     // 체크리스트 예외
     CHECKLIST_NOT_FOUND(HttpStatus.NOT_FOUND, "CHK40401", "체크리스트를 찾지 못했습니다"),
     CHECKLIST_FORBIDDEN(HttpStatus.FORBIDDEN, "CHK40301", "해당 체크리스트에 접근할 권한이 없습니다"),

--- a/src/main/java/or/hyu/ssd/global/api/ErrorCode.java
+++ b/src/main/java/or/hyu/ssd/global/api/ErrorCode.java
@@ -25,6 +25,7 @@ public enum ErrorCode {
     // 문서 예외
     DOCUMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "DOC40401", "문서를 찾지 못했습니다"),
     DOCUMENT_FORBIDDEN(HttpStatus.FORBIDDEN, "DOC40301", "해당 문서를 수정할 권한이 없습니다"),
+    DOCUMENT_PARAGRAPH_NOT_FOUND(HttpStatus.NOT_FOUND, "DOC40402", "문서의 블록을 찾지 못했습니다"),
 
     // 체크리스트 예외
     CHECKLIST_NOT_FOUND(HttpStatus.NOT_FOUND, "CHK40401", "체크리스트를 찾지 못했습니다"),


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #54 


<br><br>

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

주석 CRUD API를 구현했습니다.
blockId로 주석을 판별하여 관리합니다.


<br><br>

## 🙏 Details

<!-- 이번 PR에서 구현한 내용 중 포인트가 되는 부분을 자세하게 적어주세요 -->

주석의 내용까지 한 번에 DocumentComment에 저장을 할까 고민이 되었습니다.
이렇게 저장하게 된다면 조회 시, DocumentComment을 조회 할 쿼리&네트워크 리소스가 사라지며 동시에 이를 임시로 관리하기 위한

```
Map<Integer, String> blockContentMap = documentParagraphRepository
                .findAllByDocumentOrderByPageNumberAscBlockIdAscIdAsc(doc).stream()
                .collect(Collectors.toMap(
                        DocumentParagraph::getBlockId,
                        DocumentParagraph::getContent,
                        (a, b) -> a
                ));
```

Map 구조의 필요성도 떨어집니다.
그럼 GC와 JVM의 Heap 메모리 사용량의 부분에서도 보다 효율적일 것입니다.

하지만 그렇게 하지 않은 이유는 본문서의 수정이 일어날 경우 주석이 타겟팅하는 문서의 내용이 수정되어야하는데, 이를 리프레시 하는 로직이 별도로 필요해집니다.
이를 batch 작업으로 구현하기에는 다소 오버엔지니어링이라고 판단했습니다.

또한 해당 Map 자료구조 하나의 사용량과 쿼리(한개)로 인한 성능저하가 유의미하게 크지 않아, 현재의 구현방법을 선택하였습니다.

사실 이보다 걸리는 부분은
```
@EntityGraph(attributePaths = "member")
    List<DocumentComment> findAllByDocumentOrderByCreatedAtAsc(Document document);
```

해당 메서드가 쿼리메서드의 체이닝으로 복잡하게 얽혀있어 유지보수에 불리하다는 점, 그리고 N+1을 보완하기 위한 @EntityGraph의 활용보다 로직적으로 좋은 방법이 있을 것이라는 점입니다. (DTO 프로젝션 등...)

이를 해결하기 위해 추후 성능테스트와 함께 QueryDSL을 도입하며 성능 개선을 진행하도록 하겠습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 문서 댓글 작성, 수정, 삭제, 조회 기능 추가
  * 댓글별 작성자, 생성 시간, 블록 위치 정보 제공

* **개선사항**
  * 문서 삭제 시 관련된 모든 댓글 자동 정리

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->