### PR TITLE
[FEATURE] 폴더 CRUD 구현

### DIFF
--- a/ssd-api/build.gradle
+++ b/ssd-api/build.gradle
@@ -7,7 +7,7 @@ plugins {
 dependencies {
     implementation project(':ssd-domain')
     implementation project(':ssd-core')
-    runtimeOnly project(':ssd-infra')
+    implementation project(':ssd-infra')
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/ssd-api/src/main/java/or/hyu/ssd/domain/document/controller/DocumentController.java
+++ b/ssd-api/src/main/java/or/hyu/ssd/domain/document/controller/DocumentController.java
@@ -48,7 +48,7 @@ public class DocumentController {
                     - title (string, optional): 제목. 없으면 text/paragraphs 첫 항목으로 자동 생성
                     - text (string, required): 공백 불가 본문. 줄바꿈은 \\n 으로 이스케이프
                     - paragraphs (array, optional): 문단 메타데이터 배열 (blockId는 서버가 1..n으로 자동 부여)
-                    - path (string, optional): 폴더 경로 (예: team/project)
+                    - folderId (number, optional): 폴더 ID (없으면 루트)
 
                     ### 응답
                     - 200 OK
@@ -86,7 +86,7 @@ public class DocumentController {
                       - text (string): 새 본문
                       - summary (string): 요약 본문
                       - details (string): 상세 요약
-                      - path (string): 폴더 경로 (예: team/project)
+                      - folderId (number): 폴더 ID (0이면 루트로 이동)
                       - bookmark (boolean): 즐겨찾기 여부
                       - paragraphs (array): 문단 메타데이터 배열 (blockId는 서버가 1..n으로 자동 부여)
 
@@ -161,7 +161,7 @@ public class DocumentController {
                     ### 응답
                     - 200 OK
                     - data:
-                      - id, title, text, paragraphs, summary, details, path, bookmark
+                      - id, title, text, paragraphs, summary, details, folderId, bookmark
                       - authorId, authorName
 
                     ### 오류
@@ -196,13 +196,16 @@ public class DocumentController {
                       - OLDEST: 생성일 오래된순
                       - NAME: 제목 오름차순
                       - MODIFIED: 수정일 최신순
+                    - Query folderId (optional)
+                      - 없으면 전체
+                      - 0이면 루트
 
                     ### 응답
                     - 200 OK
                     - data[]
                       - id: 문서 ID
                       - title: 제목
-                      - path: 폴더 경로
+                      - folderId: 폴더 ID (없으면 루트)
                       - updatedAt: 마지막 수정 시각
 
                     ### 오류
@@ -213,9 +216,11 @@ public class DocumentController {
     public ResponseEntity<ApiResponse<List<DocumentListItemResponse>>> listDocuments(
             @AuthenticationPrincipal CustomUserDetails user,
             @Parameter(description = "정렬 옵션", schema = @Schema(allowableValues = {"LATEST","OLDEST","NAME","MODIFIED"}))
-            @RequestParam(name = "sort", defaultValue = "LATEST") DocumentSort sort
+            @RequestParam(name = "sort", defaultValue = "LATEST") DocumentSort sort,
+            @Parameter(description = "폴더 ID (없으면 전체, 0이면 루트)")
+            @RequestParam(name = "folderId", required = false) Long folderId
     ) {
-        List<DocumentListItemResponse> list = documentService.listDocuments(user, sort);
+        List<DocumentListItemResponse> list = documentService.listDocuments(user, sort, folderId);
         return ResponseEntity.ok(ApiResponse.ok(list, "문서 목록이 조회되었습니다"));
     }
 

--- a/ssd-api/src/main/java/or/hyu/ssd/domain/document/controller/FolderController.java
+++ b/ssd-api/src/main/java/or/hyu/ssd/domain/document/controller/FolderController.java
@@ -1,0 +1,153 @@
+package or.hyu.ssd.domain.document.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import or.hyu.ssd.domain.document.controller.dto.CreateFolderRequest;
+import or.hyu.ssd.domain.document.controller.dto.CreateFolderResponse;
+import or.hyu.ssd.domain.document.controller.dto.FolderListItemResponse;
+import or.hyu.ssd.domain.document.controller.dto.UpdateFolderRequest;
+import or.hyu.ssd.domain.document.controller.dto.UpdateFolderResponse;
+import or.hyu.ssd.domain.document.service.FolderService;
+import or.hyu.ssd.domain.member.service.CustomUserDetails;
+import or.hyu.ssd.global.api.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+@Tag(
+        name = "폴더 API",
+        description = "폴더 CRUD 엔드포인트"
+)
+public class FolderController {
+
+    private final FolderService folderService;
+
+    @PostMapping("/v1/folders")
+    @Operation(
+            summary = "폴더 생성",
+            description = """
+                    ### 개요
+                    - 새 폴더를 생성하고 ID를 반환합니다.
+
+                    ### 인증
+                    - Authorization: Bearer {accessToken}
+
+                    ### 요청 본문
+                    - name (string, required): 폴더명
+                    - color (string, optional): 폴더 색상 (HEX 등)
+                    - parentId (number, optional): 상위 폴더 ID (없으면 루트)
+
+                    ### 응답
+                    - 200 OK
+                    - data.id: 생성된 폴더 ID
+                    """
+    )
+    public ResponseEntity<ApiResponse<CreateFolderResponse>> createFolder(
+            @Valid @RequestBody CreateFolderRequest request,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        CreateFolderResponse dto = folderService.create(user, request);
+        return ResponseEntity.ok(ApiResponse.ok(dto, "폴더가 생성되었습니다"));
+    }
+
+    @PatchMapping("/v1/folders/{id}")
+    @Operation(
+            summary = "폴더 수정",
+            description = """
+                    ### 개요
+                    - 폴더 이름/색상/위치를 수정합니다.
+
+                    ### 인증
+                    - Authorization: Bearer {accessToken} (폴더 소유자만)
+
+                    ### 요청
+                    - Path: /api/v1/folders/{id}
+                    - Body(JSON, required)
+                      - name (string, optional): 새 폴더명
+                      - color (string, optional): 새 폴더 색상
+                      - parentId (number, optional): 상위 폴더 ID (0이면 루트로 이동)
+
+                    ### 응답
+                    - 200 OK
+                    - data.id: 수정된 폴더 ID
+                    """
+    )
+    public ResponseEntity<ApiResponse<UpdateFolderResponse>> updateFolder(
+            @Parameter(description = "수정할 폴더 ID", example = "42")
+            @PathVariable("id") Long id,
+            @RequestBody UpdateFolderRequest request,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        UpdateFolderResponse dto = folderService.update(id, user, request);
+        return ResponseEntity.ok(ApiResponse.ok(dto, "폴더가 수정되었습니다"));
+    }
+
+    @DeleteMapping("/v1/folders/{id}")
+    @Operation(
+            summary = "폴더 삭제",
+            description = """
+                    ### 개요
+                    - 폴더와 하위 폴더, 포함된 문서를 모두 삭제합니다.
+
+                    ### 인증
+                    - Authorization: Bearer {accessToken} (폴더 소유자만)
+
+                    ### 요청
+                    - Path: /api/v1/folders/{id}
+
+                    ### 응답
+                    - 200 OK
+                    - data: "폴더가 삭제되었습니다"
+                    """
+    )
+    public ResponseEntity<ApiResponse<String>> deleteFolder(
+            @Parameter(description = "삭제할 폴더 ID", example = "42")
+            @PathVariable("id") Long id,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        folderService.delete(id, user);
+        return ResponseEntity.ok(ApiResponse.ok("폴더가 삭제되었습니다"));
+    }
+
+    @GetMapping("/v1/folders")
+    @Operation(
+            summary = "폴더 목록 조회",
+            description = """
+                    ### 개요
+                    - 특정 부모 폴더의 하위 폴더 목록을 조회합니다.
+
+                    ### 인증
+                    - Authorization: Bearer {accessToken}
+
+                    ### 요청
+                    - Query parentId (optional): 상위 폴더 ID (없으면 루트)
+
+                    ### 응답
+                    - 200 OK
+                    - data[]
+                      - id: 폴더 ID
+                      - name: 폴더명
+                      - color: 폴더 색상
+                      - parentId: 상위 폴더 ID
+                      - hasChildren: 하위 폴더 존재 여부
+                      - updatedAt: 마지막 수정 시각
+                    """
+    )
+    public ResponseEntity<ApiResponse<List<FolderListItemResponse>>> listFolders(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @Parameter(description = "상위 폴더 ID (없으면 루트)", schema = @Schema(type = "integer", example = "0"))
+            @RequestParam(name = "parentId", required = false) Long parentId
+    ) {
+        List<FolderListItemResponse> list = folderService.list(user, parentId);
+        return ResponseEntity.ok(ApiResponse.ok(list, "폴더 목록이 조회되었습니다"));
+    }
+}

--- a/ssd-api/src/main/java/or/hyu/ssd/domain/document/controller/FolderController.java
+++ b/ssd-api/src/main/java/or/hyu/ssd/domain/document/controller/FolderController.java
@@ -8,7 +8,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import or.hyu.ssd.domain.document.controller.dto.CreateFolderRequest;
 import or.hyu.ssd.domain.document.controller.dto.CreateFolderResponse;
-import or.hyu.ssd.domain.document.controller.dto.FolderListItemResponse;
+import or.hyu.ssd.domain.document.controller.dto.FolderContentResponse;
 import or.hyu.ssd.domain.document.controller.dto.UpdateFolderRequest;
 import or.hyu.ssd.domain.document.controller.dto.UpdateFolderResponse;
 import or.hyu.ssd.domain.document.service.FolderService;
@@ -17,8 +17,6 @@ import or.hyu.ssd.global.api.ApiResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/api")
@@ -123,31 +121,28 @@ public class FolderController {
             summary = "폴더 목록 조회",
             description = """
                     ### 개요
-                    - 특정 부모 폴더의 하위 폴더 목록을 조회합니다.
+                    - 특정 부모 폴더의 하위 폴더와 문서를 함께 조회합니다.
 
                     ### 인증
                     - Authorization: Bearer {accessToken}
 
                     ### 요청
-                    - Query parentId (optional): 상위 폴더 ID (없으면 루트)
+                    - Query parentId (optional): 부모 폴더 ID (없으면 루트)
 
                     ### 응답
                     - 200 OK
                     - data[]
-                      - id: 폴더 ID
-                      - name: 폴더명
-                      - color: 폴더 색상
-                      - parentId: 상위 폴더 ID
-                      - hasChildren: 하위 폴더 존재 여부
-                      - updatedAt: 마지막 수정 시각
+                      - parentId: 현재 조회한 부모 폴더 ID (루트는 0)
+                      - folders[]: 하위 폴더 목록
+                      - documents[]: 해당 폴더 내부 문서 목록
                     """
     )
-    public ResponseEntity<ApiResponse<List<FolderListItemResponse>>> listFolders(
+    public ResponseEntity<ApiResponse<FolderContentResponse>> listFolders(
             @AuthenticationPrincipal CustomUserDetails user,
-            @Parameter(description = "상위 폴더 ID (없으면 루트)", schema = @Schema(type = "integer", example = "0"))
+            @Parameter(description = "부모 폴더 ID (없으면 루트)", schema = @Schema(type = "integer", example = "0"))
             @RequestParam(name = "parentId", required = false) Long parentId
     ) {
-        List<FolderListItemResponse> list = folderService.list(user, parentId);
-        return ResponseEntity.ok(ApiResponse.ok(list, "폴더 목록이 조회되었습니다"));
+        FolderContentResponse data = folderService.listContent(user, parentId);
+        return ResponseEntity.ok(ApiResponse.ok(data, "폴더 내용이 조회되었습니다"));
     }
 }

--- a/ssd-core/src/main/java/or/hyu/ssd/global/api/ErrorCode.java
+++ b/ssd-core/src/main/java/or/hyu/ssd/global/api/ErrorCode.java
@@ -27,6 +27,11 @@ public enum ErrorCode {
     DOCUMENT_FORBIDDEN(HttpStatus.FORBIDDEN, "DOC40301", "해당 문서를 수정할 권한이 없습니다"),
     DOCUMENT_PARAGRAPH_NOT_FOUND(HttpStatus.NOT_FOUND, "DOC40402", "문서의 블록을 찾지 못했습니다"),
 
+    // 폴더 예외
+    FOLDER_NOT_FOUND(HttpStatus.NOT_FOUND, "FOLDER40401", "폴더를 찾지 못했습니다"),
+    FOLDER_FORBIDDEN(HttpStatus.FORBIDDEN, "FOLDER40301", "해당 폴더에 접근할 권한이 없습니다"),
+    FOLDER_INVALID_PARENT(HttpStatus.BAD_REQUEST, "FOLDER40001", "잘못된 폴더 이동입니다"),
+
     // 주석 예외
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "CMT40401", "주석을 찾지 못했습니다"),
     COMMENT_FORBIDDEN(HttpStatus.FORBIDDEN, "CMT40301", "해당 주석을 수정할 권한이 없습니다"),

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/CreateDocumentRequest.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/CreateDocumentRequest.java
@@ -8,5 +8,5 @@ public record CreateDocumentRequest(
         @NotBlank(message = "내용은 필수입니다")
         String text,
         List<DocumentParagraphDto> paragraphs,
-        String path
+        Long folderId
 ) {}

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/CreateFolderRequest.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/CreateFolderRequest.java
@@ -1,0 +1,10 @@
+package or.hyu.ssd.domain.document.controller.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CreateFolderRequest(
+        @NotBlank(message = "폴더명은 필수입니다")
+        String name,
+        String color,
+        Long parentId
+) {}

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/CreateFolderResponse.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/CreateFolderResponse.java
@@ -1,0 +1,7 @@
+package or.hyu.ssd.domain.document.controller.dto;
+
+public record CreateFolderResponse(Long id) {
+    public static CreateFolderResponse of(Long id) {
+        return new CreateFolderResponse(id);
+    }
+}

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/DocumentListItemResponse.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/DocumentListItemResponse.java
@@ -6,14 +6,14 @@ import java.time.LocalDateTime;
 public record DocumentListItemResponse(
         Long id,
         String title,
-        String path,
+        Long folderId,
         LocalDateTime updatedAt
 ) {
     public static DocumentListItemResponse of(Document doc) {
         return new DocumentListItemResponse(
                 doc.getId(),
                 doc.getTitle(),
-                doc.getPath(),
+                doc.getFolder() != null ? doc.getFolder().getId() : null,
                 doc.getUpdatedAt()
         );
     }

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/FolderContentResponse.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/FolderContentResponse.java
@@ -1,0 +1,17 @@
+package or.hyu.ssd.domain.document.controller.dto;
+
+import java.util.List;
+
+public record FolderContentResponse(
+        Long parentId,
+        List<FolderListItemResponse> folders,
+        List<DocumentListItemResponse> documents
+) {
+    public static FolderContentResponse of(
+            Long parentId,
+            List<FolderListItemResponse> folders,
+            List<DocumentListItemResponse> documents
+    ) {
+        return new FolderContentResponse(parentId, folders, documents);
+    }
+}

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/FolderListItemResponse.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/FolderListItemResponse.java
@@ -1,0 +1,25 @@
+package or.hyu.ssd.domain.document.controller.dto;
+
+import or.hyu.ssd.domain.document.entity.Folder;
+
+import java.time.LocalDateTime;
+
+public record FolderListItemResponse(
+        Long id,
+        String name,
+        String color,
+        Long parentId,
+        boolean hasChildren,
+        LocalDateTime updatedAt
+) {
+    public static FolderListItemResponse of(Folder folder, boolean hasChildren) {
+        return new FolderListItemResponse(
+                folder.getId(),
+                folder.getName(),
+                folder.getColor(),
+                folder.getParent() != null ? folder.getParent().getId() : null,
+                hasChildren,
+                folder.getUpdatedAt()
+        );
+    }
+}

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/GetDocumentResponse.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/GetDocumentResponse.java
@@ -10,7 +10,7 @@ public record GetDocumentResponse(
         List<DocumentParagraphDto> paragraphs,
         String summary,
         String details,
-        String path,
+        Long folderId,
         boolean bookmark,
         Long authorId,
         String authorName
@@ -25,7 +25,7 @@ public record GetDocumentResponse(
                 paragraphs,
                 doc.getSummary(),
                 doc.getDetails(),
-                doc.getPath(),
+                doc.getFolder() != null ? doc.getFolder().getId() : null,
                 doc.isBookmark(),
                 authorId,
                 authorName

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/UpdateDocumentRequest.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/UpdateDocumentRequest.java
@@ -7,7 +7,7 @@ public record UpdateDocumentRequest(
         String text,
         String summary,
         String details,
-        String path,
+        Long folderId,
         Boolean bookmark,
         List<DocumentParagraphDto> paragraphs
 ) {}

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/UpdateFolderRequest.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/UpdateFolderRequest.java
@@ -1,0 +1,7 @@
+package or.hyu.ssd.domain.document.controller.dto;
+
+public record UpdateFolderRequest(
+        String name,
+        String color,
+        Long parentId
+) {}

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/UpdateFolderResponse.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/UpdateFolderResponse.java
@@ -1,0 +1,7 @@
+package or.hyu.ssd.domain.document.controller.dto;
+
+public record UpdateFolderResponse(Long id) {
+    public static UpdateFolderResponse of(Long id) {
+        return new UpdateFolderResponse(id);
+    }
+}

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/document/entity/Document.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/document/entity/Document.java
@@ -4,7 +4,6 @@ import jakarta.persistence.*;
 import lombok.*;
 import or.hyu.ssd.domain.member.entity.Member;
 import or.hyu.ssd.global.entity.BaseEntity;
-import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.Comment;
 
 @Entity
@@ -27,10 +26,10 @@ public class Document extends BaseEntity {
     @Column(name = "content", nullable = false, columnDefinition = "TEXT")
     private String content;
 
-    @Comment("문서 경로(폴더 경로) (입력: path)")
-    @Column(name = "path", nullable = false, length = 512)
-    @ColumnDefault("''")
-    private String path;
+    @Comment("문서가 속한 폴더 (없으면 루트)")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "folder_id")
+    private Folder folder;
 
     @Comment("사업계획서 즐겨찾기 여부 (입력: bookmark)")
     @Column(name = "bookmark", nullable = false)
@@ -83,24 +82,27 @@ public class Document extends BaseEntity {
 
 
 
-    public static Document of(String title, String content, String path, boolean bookmark, Member member) {
+    public static Document of(String title, String content, Folder folder, boolean bookmark, Member member) {
         return Document.builder()
                 .title(title)
                 .content(content)
-                .path(path)
+                .folder(folder)
                 .bookmark(bookmark)
                 .member(member)
                 .build();
     }
 
     // 부분/전체 수정 편의 메서드
-    public void updateIfPresent(String title, String content, String summary, String details, String path, Boolean bookmark) {
+    public void updateIfPresent(String title, String content, String summary, String details, Boolean bookmark) {
         if (title != null) this.title = title;
         if (content != null) this.content = content;
         if (summary != null) this.summary = summary;
         if (details != null) this.details = details;
-        if (path != null) this.path = path;
         if (bookmark != null) this.bookmark = bookmark;
+    }
+
+    public void updateFolder(Folder folder) {
+        this.folder = folder;
     }
 
     public void updateEvaluation(String evaluation) {

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/document/entity/Folder.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/document/entity/Folder.java
@@ -1,0 +1,71 @@
+package or.hyu.ssd.domain.document.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import or.hyu.ssd.domain.member.entity.Member;
+import or.hyu.ssd.global.entity.BaseEntity;
+import org.hibernate.annotations.Comment;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+@Builder
+@Table(
+        name = "folders",
+        indexes = {
+                @Index(name = "idx_folder_member_id", columnList = "member_id"),
+                @Index(name = "idx_folder_parent_id", columnList = "parent_id")
+        }
+)
+@Comment("문서 폴더 엔티티")
+public class Folder extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Comment("폴더명")
+    @Column(name = "name", nullable = false, length = 120)
+    private String name;
+
+    @Comment("폴더 색상 (HEX 등)")
+    @Column(name = "color", length = 20)
+    private String color;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private Folder parent;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Version
+    private Long version;
+
+    public static Folder of(String name, String color, Folder parent, Member member) {
+        return Folder.builder()
+                .name(name)
+                .color(color)
+                .parent(parent)
+                .member(member)
+                .build();
+    }
+
+    public void updateIfPresent(String name, String color, Folder parent) {
+        if (name != null) {
+            this.name = name;
+        }
+        if (color != null) {
+            this.color = color;
+        }
+        if (parent != null) {
+            this.parent = parent;
+        }
+    }
+
+    public void updateParent(Folder parent) {
+        this.parent = parent;
+    }
+}

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/document/repository/DocumentRepository.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/document/repository/DocumentRepository.java
@@ -13,6 +13,12 @@ public interface DocumentRepository {
 
     List<Document> findAllByMember_Id(Long memberId, Sort sort);
 
+    List<Document> findAllByMember_IdAndFolder_Id(Long memberId, Long folderId, Sort sort);
+
+    List<Document> findAllByMember_IdAndFolderIsNull(Long memberId, Sort sort);
+
+    List<Document> findAllByFolder_Id(Long folderId);
+
     void delete(Document document);
 
     void flush();

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/document/repository/FolderRepository.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/document/repository/FolderRepository.java
@@ -1,0 +1,23 @@
+package or.hyu.ssd.domain.document.repository;
+
+import or.hyu.ssd.domain.document.entity.Folder;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface FolderRepository {
+
+    Folder save(Folder folder);
+
+    Optional<Folder> findById(Long id);
+
+    Optional<Folder> findByIdAndMember_Id(Long id, Long memberId);
+
+    List<Folder> findAllByMember_IdAndParent_Id(Long memberId, Long parentId);
+
+    List<Folder> findAllByMember_IdAndParentIsNull(Long memberId);
+
+    boolean existsByMember_IdAndParent_Id(Long memberId, Long parentId);
+
+    void delete(Folder folder);
+}

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/document/service/FolderService.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/document/service/FolderService.java
@@ -1,0 +1,156 @@
+package or.hyu.ssd.domain.document.service;
+
+import lombok.RequiredArgsConstructor;
+import or.hyu.ssd.domain.document.controller.dto.CreateFolderRequest;
+import or.hyu.ssd.domain.document.controller.dto.CreateFolderResponse;
+import or.hyu.ssd.domain.document.controller.dto.FolderListItemResponse;
+import or.hyu.ssd.domain.document.controller.dto.UpdateFolderRequest;
+import or.hyu.ssd.domain.document.controller.dto.UpdateFolderResponse;
+import or.hyu.ssd.domain.document.entity.Document;
+import or.hyu.ssd.domain.document.entity.Folder;
+import or.hyu.ssd.domain.document.repository.DocumentRepository;
+import or.hyu.ssd.domain.document.repository.FolderRepository;
+import or.hyu.ssd.domain.member.service.CustomUserDetails;
+import or.hyu.ssd.global.api.ErrorCode;
+import or.hyu.ssd.global.api.handler.UserExceptionHandler;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class FolderService {
+
+    private final FolderRepository folderRepository;
+    private final DocumentRepository documentRepository;
+    private final DocumentService documentService;
+
+    public CreateFolderResponse create(CustomUserDetails user, CreateFolderRequest request) {
+        ensureAuthenticated(user);
+
+        String name = request.name().trim();
+        String color = trimOrNull(request.color());
+        Folder parent = resolveParent(user, request.parentId());
+
+        Folder saved = folderRepository.save(Folder.of(name, color, parent, user.getMember()));
+        return CreateFolderResponse.of(saved.getId());
+    }
+
+    public UpdateFolderResponse update(Long folderId, CustomUserDetails user, UpdateFolderRequest request) {
+        Folder folder = getFolderOwned(folderId, user);
+
+        String name = trimOrNull(request.name());
+        String color = trimOrNull(request.color());
+        if (name != null || color != null) {
+            folder.updateIfPresent(name, color, null);
+        }
+
+        if (request.parentId() != null) {
+            if (request.parentId() == 0L) {
+                folder.updateParent(null);
+            } else {
+                Folder newParent = getFolderOwned(request.parentId(), user);
+                ensureMovable(folder, newParent);
+                folder.updateParent(newParent);
+            }
+        }
+
+        return UpdateFolderResponse.of(folder.getId());
+    }
+
+    public void delete(Long folderId, CustomUserDetails user) {
+        Folder folder = getFolderOwned(folderId, user);
+        deleteRecursively(folder, user);
+    }
+
+    @Transactional(readOnly = true)
+    public List<FolderListItemResponse> list(CustomUserDetails user, Long parentId) {
+        ensureAuthenticated(user);
+        Long memberId = user.getMember().getId();
+
+        List<Folder> folders;
+        if (parentId == null || parentId == 0L) {
+            folders = folderRepository.findAllByMember_IdAndParentIsNull(memberId);
+        } else {
+            getFolderOwned(parentId, user);
+            folders = folderRepository.findAllByMember_IdAndParent_Id(memberId, parentId);
+        }
+
+        return folders.stream()
+                .map(folder -> FolderListItemResponse.of(
+                        folder,
+                        folderRepository.existsByMember_IdAndParent_Id(memberId, folder.getId())
+                ))
+                .collect(Collectors.toList());
+    }
+
+    private void deleteRecursively(Folder folder, CustomUserDetails user) {
+        List<Document> documents = documentRepository.findAllByFolder_Id(folder.getId());
+        for (Document document : documents) {
+            documentService.deleteDocument(document.getId(), user);
+        }
+
+        List<Folder> children = folderRepository.findAllByMember_IdAndParent_Id(
+                folder.getMember().getId(),
+                folder.getId()
+        );
+        for (Folder child : children) {
+            deleteRecursively(child, user);
+        }
+
+        folderRepository.delete(folder);
+    }
+
+    private Folder resolveParent(CustomUserDetails user, Long parentId) {
+        if (parentId == null || parentId == 0L) {
+            return null;
+        }
+        return getFolderOwned(parentId, user);
+    }
+
+    private Folder getFolderOwned(Long folderId, CustomUserDetails user) {
+        Folder folder = folderRepository.findById(folderId)
+                .orElseThrow(() -> new UserExceptionHandler(ErrorCode.FOLDER_NOT_FOUND));
+        ensureOwner(folder, user);
+        return folder;
+    }
+
+    private void ensureOwner(Folder folder, CustomUserDetails user) {
+        if (folder.getMember() == null || user == null || user.getMember() == null) {
+            throw new UserExceptionHandler(ErrorCode.FOLDER_FORBIDDEN);
+        }
+        if (!folder.getMember().getId().equals(user.getMember().getId())) {
+            throw new UserExceptionHandler(ErrorCode.FOLDER_FORBIDDEN);
+        }
+    }
+
+    private void ensureAuthenticated(CustomUserDetails user) {
+        if (user == null || user.getMember() == null) {
+            throw new UserExceptionHandler(ErrorCode.MEMBER_NOT_FOUND);
+        }
+    }
+
+    private void ensureMovable(Folder folder, Folder newParent) {
+        if (folder.getId().equals(newParent.getId())) {
+            throw new UserExceptionHandler(ErrorCode.FOLDER_INVALID_PARENT);
+        }
+        Folder cursor = newParent;
+        while (cursor != null) {
+            if (cursor.getId().equals(folder.getId())) {
+                throw new UserExceptionHandler(ErrorCode.FOLDER_INVALID_PARENT);
+            }
+            cursor = cursor.getParent();
+        }
+    }
+
+    private String trimOrNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+}

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/document/service/SummaryService.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/document/service/SummaryService.java
@@ -31,7 +31,7 @@ public class SummaryService {
         String content = doc.getContent();
 
         if (content == null || content.isBlank()) {
-            doc.updateIfPresent(null, null, null, null, null, null);
+            doc.updateIfPresent(null, null, null, null, null);
             return ThreeLineSummaryResponse.of(doc.getId(), List.of());
         }
 
@@ -53,7 +53,7 @@ public class SummaryService {
         }
 
         String summary = String.join("\n", three);
-        doc.updateIfPresent(null, null, summary, null, null, null);
+        doc.updateIfPresent(null, null, summary, null, null);
         return ThreeLineSummaryResponse.of(doc.getId(), three);
     }
 
@@ -74,7 +74,7 @@ public class SummaryService {
 
     public void delete(Long documentId, CustomUserDetails user) {
         Document doc = getOwnedDocument(documentId, user);
-        doc.updateIfPresent(null, null, null, null, null, null);
+        doc.updateIfPresent(null, null, null, null, null);
     }
 
     private Document getOwnedDocument(Long documentId, CustomUserDetails user) {

--- a/ssd-infra/src/main/java/or/hyu/ssd/infra/document/repository/DocumentRepositoryImpl.java
+++ b/ssd-infra/src/main/java/or/hyu/ssd/infra/document/repository/DocumentRepositoryImpl.java
@@ -31,6 +31,21 @@ public class DocumentRepositoryImpl implements DocumentRepository {
     }
 
     @Override
+    public List<Document> findAllByMember_IdAndFolder_Id(Long memberId, Long folderId, Sort sort) {
+        return documentJpaRepository.findAllByMember_IdAndFolder_Id(memberId, folderId, sort);
+    }
+
+    @Override
+    public List<Document> findAllByMember_IdAndFolderIsNull(Long memberId, Sort sort) {
+        return documentJpaRepository.findAllByMember_IdAndFolderIsNull(memberId, sort);
+    }
+
+    @Override
+    public List<Document> findAllByFolder_Id(Long folderId) {
+        return documentJpaRepository.findAllByFolder_Id(folderId);
+    }
+
+    @Override
     public void delete(Document document) {
         documentJpaRepository.delete(document);
     }

--- a/ssd-infra/src/main/java/or/hyu/ssd/infra/document/repository/FolderRepositoryImpl.java
+++ b/ssd-infra/src/main/java/or/hyu/ssd/infra/document/repository/FolderRepositoryImpl.java
@@ -1,0 +1,52 @@
+package or.hyu.ssd.infra.document.repository;
+
+import lombok.RequiredArgsConstructor;
+import or.hyu.ssd.domain.document.entity.Folder;
+import or.hyu.ssd.domain.document.repository.FolderRepository;
+import or.hyu.ssd.infra.document.repository.jpa.FolderJpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class FolderRepositoryImpl implements FolderRepository {
+
+    private final FolderJpaRepository folderJpaRepository;
+
+    @Override
+    public Folder save(Folder folder) {
+        return folderJpaRepository.save(folder);
+    }
+
+    @Override
+    public Optional<Folder> findById(Long id) {
+        return folderJpaRepository.findById(id);
+    }
+
+    @Override
+    public Optional<Folder> findByIdAndMember_Id(Long id, Long memberId) {
+        return folderJpaRepository.findByIdAndMember_Id(id, memberId);
+    }
+
+    @Override
+    public List<Folder> findAllByMember_IdAndParent_Id(Long memberId, Long parentId) {
+        return folderJpaRepository.findAllByMember_IdAndParent_Id(memberId, parentId);
+    }
+
+    @Override
+    public List<Folder> findAllByMember_IdAndParentIsNull(Long memberId) {
+        return folderJpaRepository.findAllByMember_IdAndParentIsNull(memberId);
+    }
+
+    @Override
+    public boolean existsByMember_IdAndParent_Id(Long memberId, Long parentId) {
+        return folderJpaRepository.existsByMember_IdAndParent_Id(memberId, parentId);
+    }
+
+    @Override
+    public void delete(Folder folder) {
+        folderJpaRepository.delete(folder);
+    }
+}

--- a/ssd-infra/src/main/java/or/hyu/ssd/infra/document/repository/jpa/DocumentJpaRepository.java
+++ b/ssd-infra/src/main/java/or/hyu/ssd/infra/document/repository/jpa/DocumentJpaRepository.java
@@ -8,4 +8,10 @@ import java.util.List;
 
 public interface DocumentJpaRepository extends JpaRepository<Document, Long> {
     List<Document> findAllByMember_Id(Long memberId, Sort sort);
+
+    List<Document> findAllByMember_IdAndFolder_Id(Long memberId, Long folderId, Sort sort);
+
+    List<Document> findAllByMember_IdAndFolderIsNull(Long memberId, Sort sort);
+
+    List<Document> findAllByFolder_Id(Long folderId);
 }

--- a/ssd-infra/src/main/java/or/hyu/ssd/infra/document/repository/jpa/FolderJpaRepository.java
+++ b/ssd-infra/src/main/java/or/hyu/ssd/infra/document/repository/jpa/FolderJpaRepository.java
@@ -1,0 +1,17 @@
+package or.hyu.ssd.infra.document.repository.jpa;
+
+import or.hyu.ssd.domain.document.entity.Folder;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface FolderJpaRepository extends JpaRepository<Folder, Long> {
+    Optional<Folder> findByIdAndMember_Id(Long id, Long memberId);
+
+    List<Folder> findAllByMember_IdAndParent_Id(Long memberId, Long parentId);
+
+    List<Folder> findAllByMember_IdAndParentIsNull(Long memberId);
+
+    boolean existsByMember_IdAndParent_Id(Long memberId, Long parentId);
+}


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #60 


<br><br>

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

- 문서를 담을 수 있는 폴더 API를 구현하였습니다.
- 그에 기반한 문서 API도 일부분 수정되었습니다.


<br><br>

## 🙏 Details

<!-- 이번 PR에서 구현한 내용 중 포인트가 되는 부분을 자세하게 적어주세요 -->


### 1. 트리 무결성 유지
  폴더 구조는 parent_id를 이용한 자기참조 트리이기 때문에, 이동 기능을 잘못 구현하면 순환 구조가 생길 수 있습니다. 순환이 발생하면 조회 로직이 무한 루프에 빠지거나 계층 계산이 깨질 위험이 있습니다.
  이번 구현에서는 폴더 이동 시 두 가지를 필수로 검증했습니다. 첫째, 자기 자신을 부모로 지정하는 요청을 차단했습니다. 둘째, 새 부모 폴더에서 상위 폴더를 따라 루트까지 올라가며 현재 폴더 ID가 다시 등장하는지 확인했습니다. 이 검증을 통해 자식 폴더 아래로 이동하는 잘못된 요청도 방지했습니다.
  또한 폴더는 사용자 전용이므로 이동 대상 폴더와 새 부모 폴더 모두에 대해 소유권 검증을 수행했습니다. 이를 통해 트리 무결성과 권한 경계를 함께 유지하도록 구성했습니다.

  ### 2. 삭제 정책
  요구사항은 폴더 삭제 시 하위 폴더와 하위 문서를 모두 삭제하는 것입니다. 단순히 폴더 행만 삭제하면 문서 및 연관 데이터가 남아 데이터 정합성이 깨질 수 있기 때문이죠.

  그래서 삭제는 재귀 방식으로 구현했습니다. 먼저 현재 폴더의 문서를 조회하고 문서 삭제 서비스를 통해 삭제했습니다. 문서 삭제 서비스 내부에서는 체크리스트, 주석, 로그 등 연관 데이터도 함께 정리했습니다. 이후 자식 폴더를 순회하며 같은 과정을 반복하고, 마지막에 현재 폴더를 삭제하도록 처리했습니다.
  이 방식의 장점은 비즈니스 규칙을 서비스 계층에서 명확하게 통제할 수 있다는 점입니다. 다만 폴더와 문서 수가 매우 많아질 경우 쿼리 수가 증가할 수 있으므로, 추후에는 배치 삭제나 쿼리 최적화를 고려할 필요가 있을 것 같아, 이는 추후 MVP 개발이 종료된 이후에 성능테스트와 함께 수정하도록 하겠습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 폴더 관리 기능 추가: 폴더 생성, 수정, 삭제 및 폴더 내 콘텐츠 조회
  * 문서를 폴더로 구성: 문서 생성 및 편집 시 폴더 지정 가능
  * 폴더별 문서 필터링: 특정 폴더의 문서만 조회
  * 폴더 계층 구조 지원: 상위 폴더 지정을 통한 중첩 폴더 구성

* **개선**
  * 경로 기반 구성에서 폴더 ID 기반 구성으로 변경

<!-- end of auto-generated comment: release notes by coderabbit.ai -->