### PR TITLE
[FIX] #65 dev 배포 nginx timeout 30분 설정

### DIFF
--- a/.github/workflows/develop-cd.yml
+++ b/.github/workflows/develop-cd.yml
@@ -52,7 +52,25 @@ jobs:
           key: ${{ secrets.KEY }}
           script: |
             cd ~/infra
+            if [ -d ./nginx/conf.d ]; then
+              cat > ./nginx/conf.d/zzz-timeout.conf <<'EOF'
+            proxy_connect_timeout 1800s;
+            proxy_send_timeout 1800s;
+            proxy_read_timeout 1800s;
+            send_timeout 1800s;
+            EOF
+            fi
             sudo docker compose down || true
             sudo docker pull ${{ secrets.DOCKER_REPO }}
             sudo docker compose up -d
             sudo docker image prune -f
+            if command -v nginx >/dev/null 2>&1; then
+              sudo tee /etc/nginx/conf.d/zzz-ssd-timeout.conf >/dev/null <<'EOF'
+            proxy_connect_timeout 1800s;
+            proxy_send_timeout 1800s;
+            proxy_read_timeout 1800s;
+            send_timeout 1800s;
+            EOF
+              sudo nginx -t
+              sudo systemctl reload nginx
+            fi


### PR DESCRIPTION
## 관련 이슈\n- #65\n\n## 변경 요약\n- dev CD 배포 SSH 스크립트에 Nginx 타임아웃 30분(1800s) 설정 로직 추가\n\n## 핵심 구현 상세\n-  경로가 존재하면 를 생성해 을 1800s로 적용\n- 호스트 Nginx가 설치된 경우 를 생성하고  후  수행\n- 기존 배포 흐름(
Usage:  docker compose [OPTIONS] COMMAND

Define and run multi-container applications with Docker

Options:
      --all-resources              Include all resources, even those not
                                   used by services
      --ansi string                Control when to print ANSI control
                                   characters ("never"|"always"|"auto")
                                   (default "auto")
      --compatibility              Run compose in backward compatibility mode
      --dry-run                    Execute command in dry run mode
      --env-file stringArray       Specify an alternate environment file
  -f, --file stringArray           Compose configuration files
      --parallel int               Control max parallelism, -1 for
                                   unlimited (default -1)
      --profile stringArray        Specify a profile to enable
      --progress string            Set type of progress output (auto,
                                   tty, plain, json, quiet) (default "auto")
      --project-directory string   Specify an alternate working directory
                                   (default: the path of the, first
                                   specified, Compose file)
  -p, --project-name string        Project name

Commands:
  attach      Attach local standard input, output, and error streams to a service's running container
  build       Build or rebuild services
  commit      Create a new image from a service container's changes
  config      Parse, resolve and render compose file in canonical format
  cp          Copy files/folders between a service container and the local filesystem
  create      Creates containers for a service
  down        Stop and remove containers, networks
  events      Receive real time events from containers
  exec        Execute a command in a running container
  export      Export a service container's filesystem as a tar archive
  images      List images used by the created containers
  kill        Force stop service containers
  logs        View output from containers
  ls          List running compose projects
  pause       Pause services
  port        Print the public port for a port binding
  ps          List containers
  pull        Pull service images
  push        Push service images
  restart     Restart service containers
  rm          Removes stopped service containers
  run         Run a one-off command on a service
  scale       Scale services 
  start       Start services
  stats       Display a live stream of container(s) resource usage statistics
  stop        Stop services
  top         Display the running processes
  unpause     Unpause services
  up          Create and start containers
  version     Show the Docker Compose version information
  wait        Block until containers of all (or specified) services stop.
  watch       Watch build context for service and rebuild/refresh containers when files are updated

Run 'docker compose COMMAND --help' for more information on a command.)은 유지

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 배포 워크플로우가 시스템 환경을 감지하여 네트워크 연결 타임아웃을 자동으로 설정하도록 개선되었습니다. 이 변경을 통해 다양한 서버 환경에서 배포 안정성과 신뢰성이 향상되며, 네트워크 문제로 인한 배포 실패가 감소할 것으로 예상됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->