### PR TITLE
[FEATURE] #66 파일 경로 전체 조회 API 구현

### DIFF
--- a/ssd-api/src/main/java/or/hyu/ssd/domain/document/controller/FolderController.java
+++ b/ssd-api/src/main/java/or/hyu/ssd/domain/document/controller/FolderController.java
@@ -132,7 +132,8 @@ public class FolderController {
                     ### 응답
                     - 200 OK
                     - data[]
-                      - parentId: 현재 조회한 부모 폴더 ID (루트는 0)
+                      - parentId: 현재 조회한 폴더 ID (루트는 0)
+                      - currentFolderId: 현재 탐색 중인 폴더 ID (루트는 0)
                       - folders[]: 하위 폴더 목록
                       - documents[]: 해당 폴더 내부 문서 목록
                     """
@@ -144,5 +145,32 @@ public class FolderController {
     ) {
         FolderContentResponse data = folderService.listContent(user, parentId);
         return ResponseEntity.ok(ApiResponse.ok(data, "폴더 내용이 조회되었습니다"));
+    }
+
+    @GetMapping("/v1/folders/all")
+    @Operation(
+            summary = "파일 경로 전체 조회",
+            description = """
+                    ### 개요
+                    - 로그인한 회원이 보유한 모든 폴더/문서를 한 번에 조회합니다.
+                    - 응답의 folders는 각 항목 parentId로 계층을 복원할 수 있습니다.
+
+                    ### 인증
+                    - Authorization: Bearer {accessToken}
+
+                    ### 응답
+                    - 200 OK
+                    - data
+                      - parentId: 0 (루트 기준)
+                      - currentFolderId: 0 (루트 기준)
+                      - folders[]: 전체 폴더 목록
+                      - documents[]: 전체 문서 목록
+                    """
+    )
+    public ResponseEntity<ApiResponse<FolderContentResponse>> listAllPaths(
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        FolderContentResponse data = folderService.listAllContent(user);
+        return ResponseEntity.ok(ApiResponse.ok(data, "파일 경로 전체 조회에 성공했습니다"));
     }
 }

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/FolderContentResponse.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/FolderContentResponse.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 public record FolderContentResponse(
         Long parentId,
+        Long currentFolderId,
         List<FolderListItemResponse> folders,
         List<DocumentListItemResponse> documents
 ) {
@@ -12,6 +13,6 @@ public record FolderContentResponse(
             List<FolderListItemResponse> folders,
             List<DocumentListItemResponse> documents
     ) {
-        return new FolderContentResponse(parentId, folders, documents);
+        return new FolderContentResponse(parentId, parentId, folders, documents);
     }
 }

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/FolderListItemResponse.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/FolderListItemResponse.java
@@ -17,7 +17,7 @@ public record FolderListItemResponse(
                 folder.getId(),
                 folder.getName(),
                 folder.getColor(),
-                folder.getParent() != null ? folder.getParent().getId() : null,
+                folder.getParent() != null ? folder.getParent().getId() : 0L,
                 hasChildren,
                 folder.getUpdatedAt()
         );

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/document/repository/FolderRepository.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/document/repository/FolderRepository.java
@@ -1,6 +1,7 @@
 package or.hyu.ssd.domain.document.repository;
 
 import or.hyu.ssd.domain.document.entity.Folder;
+import org.springframework.data.domain.Sort;
 
 import java.util.List;
 import java.util.Optional;
@@ -16,6 +17,8 @@ public interface FolderRepository {
     List<Folder> findAllByMember_IdAndParent_Id(Long memberId, Long parentId);
 
     List<Folder> findAllByMember_IdAndParentIsNull(Long memberId);
+
+    List<Folder> findAllByMember_Id(Long memberId, Sort sort);
 
     boolean existsByMember_IdAndParent_Id(Long memberId, Long parentId);
 

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/document/service/FolderService.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/document/service/FolderService.java
@@ -88,18 +88,27 @@ public class FolderService {
             documents = documentRepository.findAllByMember_IdAndFolder_Id(memberId, resolvedParentId, sort);
         }
 
-        List<FolderListItemResponse> folderItems = folders.stream()
-                .map(folder -> FolderListItemResponse.of(
-                        folder,
-                        folderRepository.existsByMember_IdAndParent_Id(memberId, folder.getId())
-                ))
-                .collect(Collectors.toList());
+        return FolderContentResponse.of(
+                resolvedParentId,
+                toFolderItems(memberId, folders),
+                toDocumentItems(documents)
+        );
+    }
 
-        List<DocumentListItemResponse> documentItems = documents.stream()
-                .map(DocumentListItemResponse::of)
-                .collect(Collectors.toList());
+    @Transactional(readOnly = true)
+    public FolderContentResponse listAllContent(CustomUserDetails user) {
+        ensureAuthenticated(user);
+        Long memberId = user.getMember().getId();
+        Sort sort = Sort.by(Sort.Order.desc("updatedAt"));
 
-        return FolderContentResponse.of(resolvedParentId, folderItems, documentItems);
+        List<Folder> folders = folderRepository.findAllByMember_Id(memberId, sort);
+        List<Document> documents = documentRepository.findAllByMember_Id(memberId, sort);
+
+        return FolderContentResponse.of(
+                0L,
+                toFolderItems(memberId, folders),
+                toDocumentItems(documents)
+        );
     }
 
     private void deleteRecursively(Folder folder, CustomUserDetails user) {
@@ -167,5 +176,20 @@ public class FolderService {
         }
         String trimmed = value.trim();
         return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    private List<FolderListItemResponse> toFolderItems(Long memberId, List<Folder> folders) {
+        return folders.stream()
+                .map(folder -> FolderListItemResponse.of(
+                        folder,
+                        folderRepository.existsByMember_IdAndParent_Id(memberId, folder.getId())
+                ))
+                .collect(Collectors.toList());
+    }
+
+    private List<DocumentListItemResponse> toDocumentItems(List<Document> documents) {
+        return documents.stream()
+                .map(DocumentListItemResponse::of)
+                .collect(Collectors.toList());
     }
 }

--- a/ssd-domain/src/test/java/or/hyu/ssd/domain/document/service/FolderServiceTest.java
+++ b/ssd-domain/src/test/java/or/hyu/ssd/domain/document/service/FolderServiceTest.java
@@ -1,0 +1,125 @@
+package or.hyu.ssd.domain.document.service;
+
+import or.hyu.ssd.domain.document.controller.dto.FolderContentResponse;
+import or.hyu.ssd.domain.document.entity.Document;
+import or.hyu.ssd.domain.document.entity.Folder;
+import or.hyu.ssd.domain.document.repository.DocumentRepository;
+import or.hyu.ssd.domain.document.repository.FolderRepository;
+import or.hyu.ssd.domain.member.entity.Member;
+import or.hyu.ssd.domain.member.entity.Role;
+import or.hyu.ssd.domain.member.service.CustomUserDetails;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Sort;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class FolderServiceTest {
+
+    @Mock
+    private FolderRepository folderRepository;
+    @Mock
+    private DocumentRepository documentRepository;
+    @Mock
+    private DocumentService documentService;
+
+    @InjectMocks
+    private FolderService folderService;
+
+    @Test
+    @DisplayName("listContent()는 현재 탐색 폴더 식별자를 포함해 직계 폴더/문서를 반환한다")
+    void listContent_includeCurrentFolderId() {
+        Member member = member(1L);
+        CustomUserDetails user = new CustomUserDetails(member);
+
+        Folder rootA = folder(1L, "작성하기", null, member);
+        Folder rootB = folder(2L, "평가하기", null, member);
+        Document rootDoc = document(101L, "루트 문서", null, member);
+
+        when(folderRepository.findAllByMember_IdAndParentIsNull(1L)).thenReturn(List.of(rootA, rootB));
+        when(documentRepository.findAllByMember_IdAndFolderIsNull(any(Long.class), any(Sort.class)))
+                .thenReturn(List.of(rootDoc));
+        when(folderRepository.existsByMember_IdAndParent_Id(1L, 1L)).thenReturn(true);
+        when(folderRepository.existsByMember_IdAndParent_Id(1L, 2L)).thenReturn(false);
+
+        FolderContentResponse result = folderService.listContent(user, null);
+
+        assertThat(result.parentId()).isEqualTo(0L);
+        assertThat(result.currentFolderId()).isEqualTo(0L);
+        assertThat(result.folders()).hasSize(2);
+        assertThat(result.documents()).hasSize(1);
+        assertThat(result.folders().get(0).parentId()).isEqualTo(0L);
+        assertThat(result.folders().get(0).hasChildren()).isTrue();
+    }
+
+    @Test
+    @DisplayName("listAllContent()는 회원의 전체 폴더/문서를 반환한다")
+    void listAllContent_returnsAllFoldersAndDocuments() {
+        Member member = member(1L);
+        CustomUserDetails user = new CustomUserDetails(member);
+
+        Folder root = folder(1L, "작성하기", null, member);
+        Folder child = folder(11L, "1분기 계획서", root, member);
+        Document docInRoot = document(101L, "사업계획서_v1.pdf", root, member);
+        Document docInChild = document(102L, "사업계획서_v2_최종.pdf", child, member);
+
+        when(folderRepository.findAllByMember_Id(any(Long.class), any(Sort.class)))
+                .thenReturn(List.of(root, child));
+        when(documentRepository.findAllByMember_Id(any(Long.class), any(Sort.class)))
+                .thenReturn(List.of(docInRoot, docInChild));
+        when(folderRepository.existsByMember_IdAndParent_Id(1L, 1L)).thenReturn(true);
+        when(folderRepository.existsByMember_IdAndParent_Id(1L, 11L)).thenReturn(false);
+
+        FolderContentResponse result = folderService.listAllContent(user);
+
+        assertThat(result.parentId()).isEqualTo(0L);
+        assertThat(result.currentFolderId()).isEqualTo(0L);
+        assertThat(result.folders()).hasSize(2);
+        assertThat(result.documents()).hasSize(2);
+        assertThat(result.folders().get(0).parentId()).isEqualTo(0L);
+        assertThat(result.folders().get(1).parentId()).isEqualTo(1L);
+        assertThat(result.documents().get(0).folderId()).isEqualTo(1L);
+        assertThat(result.documents().get(1).folderId()).isEqualTo(11L);
+    }
+
+    private Member member(Long id) {
+        return Member.builder()
+                .id(id)
+                .name("테스터")
+                .email("tester@example.com")
+                .profileImageUrl("")
+                .profileImageKey(null)
+                .role(Role.ROLE_AUTHOR)
+                .build();
+    }
+
+    private Folder folder(Long id, String name, Folder parent, Member member) {
+        return Folder.builder()
+                .id(id)
+                .name(name)
+                .color("")
+                .parent(parent)
+                .member(member)
+                .build();
+    }
+
+    private Document document(Long id, String title, Folder folder, Member member) {
+        return Document.builder()
+                .id(id)
+                .title(title)
+                .content("content")
+                .folder(folder)
+                .bookmark(false)
+                .member(member)
+                .build();
+    }
+}

--- a/ssd-infra/src/main/java/or/hyu/ssd/infra/document/repository/FolderRepositoryImpl.java
+++ b/ssd-infra/src/main/java/or/hyu/ssd/infra/document/repository/FolderRepositoryImpl.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import or.hyu.ssd.domain.document.entity.Folder;
 import or.hyu.ssd.domain.document.repository.FolderRepository;
 import or.hyu.ssd.infra.document.repository.jpa.FolderJpaRepository;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -38,6 +39,11 @@ public class FolderRepositoryImpl implements FolderRepository {
     @Override
     public List<Folder> findAllByMember_IdAndParentIsNull(Long memberId) {
         return folderJpaRepository.findAllByMember_IdAndParentIsNull(memberId);
+    }
+
+    @Override
+    public List<Folder> findAllByMember_Id(Long memberId, Sort sort) {
+        return folderJpaRepository.findAllByMember_Id(memberId, sort);
     }
 
     @Override

--- a/ssd-infra/src/main/java/or/hyu/ssd/infra/document/repository/jpa/FolderJpaRepository.java
+++ b/ssd-infra/src/main/java/or/hyu/ssd/infra/document/repository/jpa/FolderJpaRepository.java
@@ -2,6 +2,7 @@ package or.hyu.ssd.infra.document.repository.jpa;
 
 import or.hyu.ssd.domain.document.entity.Folder;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.domain.Sort;
 
 import java.util.List;
 import java.util.Optional;
@@ -12,6 +13,8 @@ public interface FolderJpaRepository extends JpaRepository<Folder, Long> {
     List<Folder> findAllByMember_IdAndParent_Id(Long memberId, Long parentId);
 
     List<Folder> findAllByMember_IdAndParentIsNull(Long memberId);
+
+    List<Folder> findAllByMember_Id(Long memberId, Sort sort);
 
     boolean existsByMember_IdAndParent_Id(Long memberId, Long parentId);
 }


### PR DESCRIPTION
## 📣 Related Issue

- close #66
- close #67


<br><br>

## 📝 Summary

- 파일 경로 전체 조회를 위한 신규 API `GET /api/v1/folders/all`를 추가했습니다.
- 폴더 목록 조회 응답에 현재 탐색 폴더 식별자(`currentFolderId`)를 명시적으로 포함하도록 확장했습니다.
- 루트 폴더의 `parentId`를 `0`으로 통일해 클라이언트 트리 렌더링 정합성을 맞췄습니다.
- `FolderService` 단위 테스트 2건을 추가했습니다.


<br><br>

## 🙏 Details

- `FolderService#listAllContent`를 추가해 회원이 보유한 전체 폴더/문서를 한 번에 조회하도록 구현했습니다.
  - 전체 폴더: `FolderRepository.findAllByMember_Id(memberId, sort)`
  - 전체 문서: `DocumentRepository.findAllByMember_Id(memberId, sort)`
  - 응답은 `FolderContentResponse(parentId=0, currentFolderId=0, folders, documents)` 형태로 반환합니다.
- `FolderController`에 `GET /api/v1/folders/all` 엔드포인트를 추가하고 Swagger 설명을 보강했습니다.
- 기존 `GET /api/v1/folders` 응답 스펙에 `currentFolderId`를 포함하도록 DTO를 확장했습니다.
  - `FolderContentResponse`에 `currentFolderId` 필드 추가
- 폴더 트리 데이터 일관성을 위해 `FolderListItemResponse`에서 루트 폴더의 `parentId`를 `0L`로 반환하도록 변경했습니다.
- `FolderRepository`/`FolderRepositoryImpl`/`FolderJpaRepository`에 전체 폴더 조회 메서드(`findAllByMember_Id`)를 추가했습니다.
- 테스트
  - `FolderServiceTest#listContent_includeCurrentFolderId`
  - `FolderServiceTest#listAllContent_returnsAllFoldersAndDocuments`
  - 실행: `./gradlew :ssd-domain:test :ssd-api:compileJava`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 인증된 사용자가 보유한 모든 폴더 및 문서를 한 눈에 조회할 수 있는 새로운 통합 API 엔드포인트 추가

## 개선사항
* 폴더 목록 응답에 현재 폴더 ID 정보 추가로 폴더 계층 구조 관리 및 네비게이션 강화
* 폴더 검색 및 조회 시 정렬 옵션 지원 추가

## 테스트
* 신규 기능 및 변경사항에 대한 포괄적인 단위 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->