### PR TITLE
[CHORE] 문서생성 API pageNumber 필드 삭제

### DIFF
--- a/ssd-api/src/main/java/or/hyu/ssd/domain/document/controller/DocumentController.java
+++ b/ssd-api/src/main/java/or/hyu/ssd/domain/document/controller/DocumentController.java
@@ -47,7 +47,7 @@ public class DocumentController {
                     ### 요청 본문
                     - title (string, optional): 제목. 없으면 text/paragraphs 첫 항목으로 자동 생성
                     - text (string, required): 공백 불가 본문. 줄바꿈은 \\n 으로 이스케이프
-                    - paragraphs (array, optional): 문단 메타데이터 배열 (blockId는 서버가 1..n으로 자동 부여)
+                    - paragraphs (array, optional): 문단 메타데이터 배열 (content, role, blockId만 입력. pageNumber는 생성 API에서 받지 않으며 1로 저장)
                     - folderId (number, optional): 폴더 ID (없으면 루트)
 
                     ### 응답

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/CreateDocumentParagraphRequest.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/CreateDocumentParagraphRequest.java
@@ -1,0 +1,7 @@
+package or.hyu.ssd.domain.document.controller.dto;
+
+public record CreateDocumentParagraphRequest(
+        String content,
+        String role,
+        Integer blockId
+) {}

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/CreateDocumentRequest.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/CreateDocumentRequest.java
@@ -7,6 +7,6 @@ public record CreateDocumentRequest(
         String title,
         @NotBlank(message = "내용은 필수입니다")
         String text,
-        List<DocumentParagraphDto> paragraphs,
+        List<CreateDocumentParagraphRequest> paragraphs,
         Long folderId
 ) {}

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/document/service/DocumentService.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/document/service/DocumentService.java
@@ -1,5 +1,6 @@
 package or.hyu.ssd.domain.document.service;
 import lombok.RequiredArgsConstructor;
+import or.hyu.ssd.domain.document.controller.dto.CreateDocumentParagraphRequest;
 import or.hyu.ssd.domain.document.controller.dto.CreateDocumentRequest;
 import or.hyu.ssd.domain.document.controller.dto.CreateDocumentResponse;
 import or.hyu.ssd.domain.document.controller.dto.DocumentListItemResponse;
@@ -57,7 +58,7 @@ public class DocumentService {
         Document doc = Document.of(title, req.text(), folder, false, user.getMember());
 
         Document saved = documentRepository.save(doc);
-        saveParagraphsIfPresent(saved, req.paragraphs());
+        saveCreateParagraphsIfPresent(saved, req.paragraphs());
         saveDocumentLog(saved, user);
         return CreateDocumentResponse.of(saved.getId());
     }
@@ -205,7 +206,7 @@ public class DocumentService {
         return folder;
     }
 
-    private String resolveTitle(String requestedTitle, String text, List<DocumentParagraphDto> paragraphs) {
+    private String resolveTitle(String requestedTitle, String text, List<CreateDocumentParagraphRequest> paragraphs) {
         String title = trimOrNull(requestedTitle);
         if (title != null) {
             return title;
@@ -246,6 +247,20 @@ public class DocumentService {
             }
         }
         return null;
+    }
+
+    private void saveCreateParagraphsIfPresent(Document doc, List<CreateDocumentParagraphRequest> paragraphs) {
+        if (paragraphs == null || paragraphs.isEmpty()) {
+            return;
+        }
+        List<DocumentParagraph> entities = new ArrayList<>(paragraphs.size());
+
+        // 생성 API는 pageNumber를 받지 않으므로 모든 문단을 1페이지로 저장합니다.
+        int blockId = 1;
+        for (CreateDocumentParagraphRequest p : paragraphs) {
+            entities.add(DocumentParagraph.of(p.content(), p.role(), 1, blockId++, doc));
+        }
+        documentParagraphRepository.saveAll(entities);
     }
 
     private void saveParagraphsIfPresent(Document doc, List<DocumentParagraphDto> paragraphs) {

--- a/ssd-domain/src/test/java/or/hyu/ssd/domain/document/service/DocumentServiceTest.java
+++ b/ssd-domain/src/test/java/or/hyu/ssd/domain/document/service/DocumentServiceTest.java
@@ -1,0 +1,123 @@
+package or.hyu.ssd.domain.document.service;
+
+import or.hyu.ssd.domain.document.controller.dto.CreateDocumentParagraphRequest;
+import or.hyu.ssd.domain.document.controller.dto.CreateDocumentRequest;
+import or.hyu.ssd.domain.document.controller.dto.CreateDocumentResponse;
+import or.hyu.ssd.domain.document.entity.Document;
+import or.hyu.ssd.domain.document.entity.DocumentParagraph;
+import or.hyu.ssd.domain.document.repository.CheckListRepository;
+import or.hyu.ssd.domain.document.repository.DocumentCommentRepository;
+import or.hyu.ssd.domain.document.repository.DocumentLogRepository;
+import or.hyu.ssd.domain.document.repository.DocumentParagraphRepository;
+import or.hyu.ssd.domain.document.repository.DocumentRepository;
+import or.hyu.ssd.domain.document.repository.EvaluatorCheckListRepository;
+import or.hyu.ssd.domain.document.repository.FolderRepository;
+import or.hyu.ssd.domain.member.entity.Member;
+import or.hyu.ssd.domain.member.entity.Role;
+import or.hyu.ssd.domain.member.service.CustomUserDetails;
+import or.hyu.ssd.global.util.OptimisticRetryExecutor;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DocumentServiceTest {
+
+    @Mock
+    private DocumentRepository documentRepository;
+    @Mock
+    private CheckListRepository checkListRepository;
+    @Mock
+    private EvaluatorCheckListRepository evaluatorCheckListRepository;
+    @Mock
+    private DocumentParagraphRepository documentParagraphRepository;
+    @Mock
+    private DocumentCommentRepository documentCommentRepository;
+    @Mock
+    private DocumentLogRepository documentLogRepository;
+    @Mock
+    private FolderRepository folderRepository;
+    @Mock
+    private OptimisticRetryExecutor optimisticRetryExecutor;
+
+    @InjectMocks
+    private DocumentService documentService;
+
+    @Test
+    @DisplayName("createDocument()는 생성 요청 문단의 pageNumber를 1로 저장하고 첫 문단으로 제목을 만든다")
+    void createDocument_defaultsPageNumberAndResolvesTitleFromParagraph() {
+        Member member = member(1L);
+        CustomUserDetails user = new CustomUserDetails(member);
+        CreateDocumentRequest request = new CreateDocumentRequest(
+                null,
+                "   ",
+                List.of(
+                        new CreateDocumentParagraphRequest("첫 문단 제목", "BODY", 99),
+                        new CreateDocumentParagraphRequest("둘째 문단", "BODY", 100)
+                ),
+                0L
+        );
+
+        when(documentRepository.save(any(Document.class))).thenAnswer(invocation -> {
+            Document doc = invocation.getArgument(0);
+            return Document.builder()
+                    .id(42L)
+                    .title(doc.getTitle())
+                    .content(doc.getContent())
+                    .folder(doc.getFolder())
+                    .bookmark(doc.isBookmark())
+                    .member(doc.getMember())
+                    .build();
+        });
+        when(documentParagraphRepository.saveAll(any())).thenAnswer(invocation -> {
+            Iterable<DocumentParagraph> paragraphs = invocation.getArgument(0);
+            List<DocumentParagraph> saved = new ArrayList<>();
+            paragraphs.forEach(saved::add);
+            return saved;
+        });
+
+        CreateDocumentResponse response = documentService.createDocument(user, request);
+
+        ArgumentCaptor<Document> documentCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(documentRepository).save(documentCaptor.capture());
+        assertThat(documentCaptor.getValue().getTitle()).isEqualTo("첫 문단 제목");
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Iterable<DocumentParagraph>> paragraphCaptor =
+                (ArgumentCaptor<Iterable<DocumentParagraph>>) (ArgumentCaptor<?>) ArgumentCaptor.forClass(Iterable.class);
+        verify(documentParagraphRepository).saveAll(paragraphCaptor.capture());
+        List<DocumentParagraph> savedParagraphs = new ArrayList<>();
+        paragraphCaptor.getValue().forEach(savedParagraphs::add);
+
+        assertThat(savedParagraphs)
+                .extracting(DocumentParagraph::getPageNumber)
+                .containsExactly(1, 1);
+        assertThat(savedParagraphs)
+                .extracting(DocumentParagraph::getBlockId)
+                .containsExactly(1, 2);
+        assertThat(response.id()).isEqualTo(42L);
+    }
+
+    private Member member(Long id) {
+        return Member.builder()
+                .id(id)
+                .name("테스터")
+                .email("tester@example.com")
+                .profileImageUrl("")
+                .profileImageKey(null)
+                .role(Role.ROLE_AUTHOR)
+                .build();
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue

- close #69


<br><br>

## 📝 Summary

- 문서 생성 요청 전용 문단 DTO를 분리해 `pageNumber` 입력을 제거했습니다.
- 생성 서비스에서 문단 저장 시 `pageNumber`를 서버 기본값 `1`로 채우도록 변경했습니다.
- 생성 API Swagger 설명과 생성 로직 테스트를 함께 정리했습니다.


<br><br>

## 🙏 Details

- `CreateDocumentRequest`의 `paragraphs` 타입을 생성 전용 DTO로 분리해 생성 API 계약만 변경하고, 조회/수정 API의 `DocumentParagraphDto` 스펙은 유지했습니다.
- `DocumentService#createDocument()`는 새 DTO를 받아 문단 엔티티 저장 시 `pageNumber=1`, `blockId=1..n` 규칙을 서버에서 일관되게 적용합니다.
- 테스트에서 생성 요청 문단의 `pageNumber` 기본값과 제목 추론(첫 문단 content 사용)을 검증해 회귀를 막았습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 문서 생성 시 단락의 페이지 번호가 자동으로 1로 설정됩니다.
  * 문서 제목이 첫 번째 단락의 내용에서 자동으로 결정됩니다.

* **Tests**
  * 문서 생성 시 페이지 번호 기본값 설정 및 제목 자동 결정 기능에 대한 테스트 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->