### PR TITLE
[FEATURE] blue/green 무중단 배포 및 인프라 설정 형상관리

### DIFF
--- a/.github/workflows/develop-cd.yml
+++ b/.github/workflows/develop-cd.yml
@@ -1,76 +1,126 @@
-name: dev-cd
+name: develop-cd
 
 on:
   push:
     branches: [ "develop" ]
 
+concurrency:
+  group: develop-cd-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
 
-      - name: Set up JDK 21
-        uses: actions/setup-java@v3
+    steps:
+      - name: 코드 가져오기
+        uses: actions/checkout@v4
+
+      - name: JDK 21 설치
+        uses: actions/setup-java@v4
         with:
           java-version: '21'
-          distribution: "adopt"
+          distribution: 'temurin'
 
+      - name: Gradle 설정
+        uses: gradle/actions/setup-gradle@v3
 
-      - name: Remove existing application-dev.yml (if exists)
-        run: |
-          rm -f ssd-api/src/main/resources/application-dev.yml
+      - name: gradlew 권한 설정
+        run: chmod +x gradlew
 
-      - name: Make application-dev.yml
+      - name: application-dev.yml 생성
         env:
           APPLICATION_DEV: ${{ secrets.APPLICATION_DEV }}
         run: |
-          mkdir -p ssd-api/src/main/resources
-          printf '%s\n' "$APPLICATION_DEV" > ssd-api/src/main/resources/application-dev.yml
+          mkdir -p .runtime
+          FILE=.runtime/application-dev.yml
+          rm -f "$FILE"
+          printf '%s\n' "$APPLICATION_DEV" > "$FILE"
 
-      - name: Build with Gradle
+          if grep -Eq '^[[:space:]]*on-profile:[[:space:]]*local' "$FILE"; then
+            echo "[WARN] application-dev.yml의 on-profile: local 을 dev로 보정합니다."
+            perl -0pi -e 's/on-profile:\s*local/on-profile: dev/g' "$FILE"
+          fi
+
+      - name: dev 설정 필수값 검증
         run: |
-          chmod +x ./gradlew
-          ./gradlew clean build -x test
+          FILE=.runtime/application-dev.yml
+          grep -Eq '^spring:' "$FILE" || { echo "[ERROR] spring 루트가 없습니다."; exit 1; }
+          grep -Eq '^[[:space:]]*datasource:' "$FILE" || { echo "[ERROR] spring.datasource 블록이 없습니다."; exit 1; }
+          grep -Eq '^[[:space:]]*url:[[:space:]]*jdbc:' "$FILE" || { echo "[ERROR] spring.datasource.url이 jdbc 형식이 아닙니다."; exit 1; }
+          grep -Eq '^[[:space:]]*username:[[:space:]]*[^[:space:]].*' "$FILE" || { echo "[ERROR] spring.datasource.username이 비어 있습니다."; exit 1; }
+          grep -Eq '^[[:space:]]*password:[[:space:]]*[^[:space:]].*' "$FILE" || { echo "[ERROR] spring.datasource.password가 비어 있습니다."; exit 1; }
+          ! grep -Eq '^[[:space:]]*on-profile:[[:space:]]*local' "$FILE" || { echo "[ERROR] on-profile: local 이 남아 있습니다."; exit 1; }
 
-      - name: Docker BUILD_PUSH
+      - name: 배포 스크립트 문법 검증
         run: |
-          docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
-          docker build -f Dockerfile -t ${{ secrets.DOCKER_REPO }} .
-          docker push ${{ secrets.DOCKER_REPO }}
+          bash -n deploy/ec2/install_infra.sh
+          bash -n deploy/ec2/blue_green_deploy.sh
 
+      - name: Docker 레포지토리 이름 정규화
+        env:
+          RAW_DOCKER_REPO: ${{ secrets.DOCKER_REPO }}
+        run: |
+          if [[ "${RAW_DOCKER_REPO##*/}" == *:* ]]; then
+            DOCKER_REPO="${RAW_DOCKER_REPO%:*}"
+          else
+            DOCKER_REPO="${RAW_DOCKER_REPO}"
+          fi
+          echo "DOCKER_REPO=${DOCKER_REPO}" >> "$GITHUB_ENV"
 
-      - name: Deploy_EC2
-        uses: appleboy/ssh-action@master
-        id: deploy
+      - name: Jib 이미지 빌드 및 푸시
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          IMAGE_SHA: ${{ github.sha }}
+        run: |
+          ./gradlew :ssd-api:jib -x test --no-daemon --build-cache \
+            -Djib.from.auth.username="${DOCKER_USERNAME}" \
+            -Djib.from.auth.password="${DOCKER_PASSWORD}" \
+            -Djib.to.image="${DOCKER_REPO}" \
+            -Djib.to.tags="${IMAGE_SHA},develop-latest" \
+            -Djib.to.auth.username="${DOCKER_USERNAME}" \
+            -Djib.to.auth.password="${DOCKER_PASSWORD}"
+
+      - name: 배포 파일 전송
+        uses: appleboy/scp-action@v0.1.7
         with:
           host: ${{ secrets.HOST }}
           username: ubuntu
           key: ${{ secrets.KEY }}
+          source: deploy/ec2
+          target: /tmp
+
+      - name: dev 설정 파일 전송
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.HOST }}
+          username: ubuntu
+          key: ${{ secrets.KEY }}
+          source: .runtime/application-dev.yml
+          target: /tmp
+
+      - name: EC2 Blue/Green 배포
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.HOST }}
+          username: ubuntu
+          key: ${{ secrets.KEY }}
+          script_stop: true
           script: |
-            cd ~/infra
-            if [ -d ./nginx/conf.d ]; then
-              cat > ./nginx/conf.d/zzz-timeout.conf <<'EOF'
-            proxy_connect_timeout 1800s;
-            proxy_send_timeout 1800s;
-            proxy_read_timeout 1800s;
-            send_timeout 1800s;
-            EOF
-            fi
-            sudo docker compose down || true
-            sudo docker pull ${{ secrets.DOCKER_REPO }}
-            sudo docker compose up -d
-            sudo docker image prune -f
-            if command -v nginx >/dev/null 2>&1; then
-              sudo tee /etc/nginx/conf.d/zzz-ssd-timeout.conf >/dev/null <<'EOF'
-            proxy_connect_timeout 1800s;
-            proxy_send_timeout 1800s;
-            proxy_read_timeout 1800s;
-            send_timeout 1800s;
-            EOF
-              sudo nginx -t
-              sudo systemctl reload nginx
-            fi
+            chmod +x /tmp/deploy/ec2/install_infra.sh /tmp/deploy/ec2/blue_green_deploy.sh
+            export APP_NAME="ssd"
+            export DOCKER_REPO="${{ env.DOCKER_REPO }}"
+            export IMAGE_TAG="${{ github.sha }}"
+            export SPRING_PROFILES_ACTIVE="dev"
+            export APP_CONFIG_SOURCE="/tmp/.runtime/application-dev.yml"
+            export APP_CONFIG_FILE="/opt/ssd/config/application-dev.yml"
+            export HEALTH_PATH="/swagger-ui/index.html"
+            export NETWORK_NAME="ssd-net"
+            export NGINX_SERVER_NAME="dev-api.simsaimdang.shop"
+            export NGINX_UPSTREAM_FILE="/etc/nginx/conf.d/ssd-upstream.conf"
+            sudo -E /tmp/deploy/ec2/install_infra.sh
+            sudo -E /tmp/deploy/ec2/blue_green_deploy.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,10 @@
 
 ### Git & Collaboration
 - 기본 브랜치 흐름: `feature/*`, `fix/*` -> `develop` -> `main`
+- 브랜치 명명 규칙
+  - 기능 작업: `feature/#이슈번호/요약`
+  - 버그 수정: `fix/#이슈번호/요약`
+  - 잡무/설정 작업: `chore/#이슈번호/요약`
 - 커밋/이슈 prefix는 현재 템플릿 관례를 따른다.
   - `[FEATURE]`, `[FIX]`, `[CHORE]`, `[INIT]`
 - 커밋 메세지는 아래와 같이 작성한다

--- a/deploy/ec2/README.md
+++ b/deploy/ec2/README.md
@@ -1,0 +1,15 @@
+# EC2 Deploy Assets
+
+이 디렉터리는 SSD dev 서버 배포에 필요한 비민감 설정을 형상관리합니다.
+
+## 포함 파일
+- `docker-compose.yml`: 공용 인프라(redis, network) 정의
+- `nginx/site.conf.template`: dev 도메인 프록시 설정 템플릿
+- `nginx/zzz-ssd-timeout.conf`: 장시간 AI 요청용 timeout 설정
+- `install_infra.sh`: 서버에 정적 인프라 파일을 설치하고 redis를 기동
+- `blue_green_deploy.sh`: blue/green 무중단 배포 스크립트
+
+## 민감 정보 분리
+- `application-dev.yml`은 Git에 커밋하지 않습니다.
+- CI에서 secret으로 생성한 뒤 서버 `/opt/ssd/config/application-dev.yml`로 배포합니다.
+- 애플리케이션 컨테이너는 외부 설정 파일을 `/config/application-dev.yml`로 마운트해 사용합니다.

--- a/deploy/ec2/blue_green_deploy.sh
+++ b/deploy/ec2/blue_green_deploy.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_NAME="${APP_NAME:-ssd}"
+DOCKER_REPO="${DOCKER_REPO:?DOCKER_REPO is required}"
+IMAGE_TAG="${IMAGE_TAG:?IMAGE_TAG is required}"
+IMAGE="${DOCKER_REPO}:${IMAGE_TAG}"
+
+LOCK_FILE="${LOCK_FILE:-/var/lock/${APP_NAME}-deploy.lock}"
+mkdir -p "$(dirname "${LOCK_FILE}")"
+exec 200>"${LOCK_FILE}"
+flock -n 200 || { echo "[ERROR] Another deployment is running"; exit 1; }
+
+SPRING_PROFILE="${SPRING_PROFILES_ACTIVE:-dev}"
+STATE_FILE="${STATE_FILE:-/opt/${APP_NAME}/active_color}"
+NETWORK_NAME="${NETWORK_NAME:-ssd-net}"
+APP_CONFIG_FILE="${APP_CONFIG_FILE:-/opt/${APP_NAME}/config/application-dev.yml}"
+SPRING_CONFIG_ADDITIONAL_LOCATION="${SPRING_CONFIG_ADDITIONAL_LOCATION:-optional:file:/config/}"
+TIME_ZONE="${APP_TIME_ZONE:-Asia/Seoul}"
+
+BLUE_PORT="${BLUE_PORT:-8080}"
+GREEN_PORT="${GREEN_PORT:-8081}"
+APP_PORT="${APP_PORT:-8080}"
+HEALTH_PATH="${HEALTH_PATH:-/swagger-ui/index.html}"
+HEALTH_TIMEOUT_SECONDS="${HEALTH_TIMEOUT_SECONDS:-120}"
+HEALTH_REQUEST_TIMEOUT_SECONDS="${HEALTH_REQUEST_TIMEOUT_SECONDS:-5}"
+HEALTH_CONNECT_TIMEOUT_SECONDS="${HEALTH_CONNECT_TIMEOUT_SECONDS:-3}"
+HEALTH_RETRY_SLEEP_SECONDS="${HEALTH_RETRY_SLEEP_SECONDS:-2}"
+
+NGINX_UPSTREAM_FILE="${NGINX_UPSTREAM_FILE:-/etc/nginx/conf.d/ssd-upstream.conf}"
+
+mkdir -p "$(dirname "${STATE_FILE}")"
+
+if [[ ! -f "${APP_CONFIG_FILE}" ]]; then
+  echo "[ERROR] application config not found: ${APP_CONFIG_FILE}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${STATE_FILE}" ]]; then
+  echo "blue" > "${STATE_FILE}"
+fi
+
+CURRENT_COLOR="$(cat "${STATE_FILE}")"
+if [[ "${CURRENT_COLOR}" == "blue" ]]; then
+  NEXT_COLOR="green"
+  NEXT_PORT="${GREEN_PORT}"
+  CURRENT_PORT="${BLUE_PORT}"
+else
+  NEXT_COLOR="blue"
+  NEXT_PORT="${BLUE_PORT}"
+  CURRENT_PORT="${GREEN_PORT}"
+fi
+
+NEXT_CONTAINER="${APP_NAME}-${NEXT_COLOR}"
+CURRENT_CONTAINER="${APP_NAME}-${CURRENT_COLOR}"
+HEALTH_URL="http://127.0.0.1:${NEXT_PORT}${HEALTH_PATH}"
+
+echo "[INFO] Current=${CURRENT_COLOR}(${CURRENT_PORT}), Next=${NEXT_COLOR}(${NEXT_PORT})"
+echo "[INFO] Pull image: ${IMAGE}"
+docker pull "${IMAGE}"
+
+docker network inspect "${NETWORK_NAME}" >/dev/null 2>&1 || docker network create "${NETWORK_NAME}"
+
+docker rm -f "${NEXT_CONTAINER}" >/dev/null 2>&1 || true
+
+echo "[INFO] Start ${NEXT_CONTAINER}"
+docker run -d \
+  --name "${NEXT_CONTAINER}" \
+  --restart unless-stopped \
+  --network "${NETWORK_NAME}" \
+  -e SPRING_PROFILES_ACTIVE="${SPRING_PROFILE}" \
+  -e SPRING_CONFIG_ADDITIONAL_LOCATION="${SPRING_CONFIG_ADDITIONAL_LOCATION}" \
+  -e TZ="${TIME_ZONE}" \
+  -v "${APP_CONFIG_FILE}:/config/application-dev.yml:ro" \
+  -p "127.0.0.1:${NEXT_PORT}:${APP_PORT}" \
+  "${IMAGE}"
+
+echo "[INFO] Health check: ${HEALTH_URL}"
+ELAPSED=0
+ATTEMPT=0
+while true; do
+  ATTEMPT=$((ATTEMPT + 1))
+
+  if curl -fsS \
+    --connect-timeout "${HEALTH_CONNECT_TIMEOUT_SECONDS}" \
+    --max-time "${HEALTH_REQUEST_TIMEOUT_SECONDS}" \
+    "${HEALTH_URL}" >/dev/null 2>&1; then
+    break
+  fi
+
+  sleep "${HEALTH_RETRY_SLEEP_SECONDS}"
+  ELAPSED=$((ELAPSED + HEALTH_REQUEST_TIMEOUT_SECONDS + HEALTH_RETRY_SLEEP_SECONDS))
+
+  if (( ELAPSED >= HEALTH_TIMEOUT_SECONDS )); then
+    echo "[ERROR] Health check timeout (${HEALTH_TIMEOUT_SECONDS}s, attempts=${ATTEMPT})"
+    docker logs "${NEXT_CONTAINER}" --tail 200 || true
+    docker rm -f "${NEXT_CONTAINER}" >/dev/null 2>&1 || true
+    exit 1
+  fi
+done
+
+cat > "${NGINX_UPSTREAM_FILE}" <<EOF_UPSTREAM
+upstream ssd_backend {
+    server 127.0.0.1:${NEXT_PORT};
+    keepalive 32;
+}
+EOF_UPSTREAM
+
+nginx -t
+systemctl reload nginx
+
+echo "${NEXT_COLOR}" > "${STATE_FILE}"
+
+docker rm -f "${CURRENT_CONTAINER}" >/dev/null 2>&1 || true
+docker image prune -f >/dev/null 2>&1 || true
+
+echo "[INFO] Deploy success: active=${NEXT_COLOR}"

--- a/deploy/ec2/docker-compose.yml
+++ b/deploy/ec2/docker-compose.yml
@@ -1,0 +1,20 @@
+name: infra
+
+services:
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    command: ["redis-server", "--appendonly", "no"]
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+    networks:
+      - ssd-net
+
+networks:
+  ssd-net:
+    name: ssd-net
+
+volumes:
+  redis-data:

--- a/deploy/ec2/install_infra.sh
+++ b/deploy/ec2/install_infra.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_NAME="${APP_NAME:-ssd}"
+DEPLOY_USER="${DEPLOY_USER:-${SUDO_USER:-ubuntu}}"
+INFRA_DIR="${INFRA_DIR:-/home/${DEPLOY_USER}/infra}"
+DEPLOY_ROOT="${DEPLOY_ROOT:-/opt/${APP_NAME}}"
+RUNTIME_CONFIG_DIR="${RUNTIME_CONFIG_DIR:-${DEPLOY_ROOT}/config}"
+APP_CONFIG_FILE="${APP_CONFIG_FILE:-${RUNTIME_CONFIG_DIR}/application-dev.yml}"
+APP_CONFIG_SOURCE="${APP_CONFIG_SOURCE:-}"
+NETWORK_NAME="${NETWORK_NAME:-ssd-net}"
+NGINX_SERVER_NAME="${NGINX_SERVER_NAME:-dev-api.simsaimdang.shop}"
+NGINX_TIMEOUT_FILE="${NGINX_TIMEOUT_FILE:-/etc/nginx/conf.d/zzz-ssd-timeout.conf}"
+NGINX_UPSTREAM_FILE="${NGINX_UPSTREAM_FILE:-/etc/nginx/conf.d/ssd-upstream.conf}"
+NGINX_SITE_AVAILABLE="${NGINX_SITE_AVAILABLE:-/etc/nginx/sites-available/${NGINX_SERVER_NAME}}"
+NGINX_SITE_ENABLED="${NGINX_SITE_ENABLED:-/etc/nginx/sites-enabled/${NGINX_SERVER_NAME}}"
+
+install -d -m 755 -o "${DEPLOY_USER}" -g "${DEPLOY_USER}" "${INFRA_DIR}"
+install -d -m 755 "${DEPLOY_ROOT}" "${RUNTIME_CONFIG_DIR}"
+install -m 644 "${SCRIPT_DIR}/docker-compose.yml" "${INFRA_DIR}/docker-compose.yml"
+chown "${DEPLOY_USER}:${DEPLOY_USER}" "${INFRA_DIR}/docker-compose.yml"
+
+if [[ -n "${APP_CONFIG_SOURCE}" ]]; then
+  install -m 600 "${APP_CONFIG_SOURCE}" "${APP_CONFIG_FILE}"
+elif [[ ! -f "${APP_CONFIG_FILE}" ]]; then
+  echo "[ERROR] application-dev.yml is required at ${APP_CONFIG_FILE}" >&2
+  exit 1
+fi
+
+if command -v docker >/dev/null 2>&1; then
+  docker network inspect "${NETWORK_NAME}" >/dev/null 2>&1 || docker network create "${NETWORK_NAME}"
+  docker compose -f "${INFRA_DIR}/docker-compose.yml" up -d --remove-orphans redis
+else
+  echo "[ERROR] docker is not installed" >&2
+  exit 1
+fi
+
+if command -v nginx >/dev/null 2>&1; then
+  install -d -m 755 /etc/nginx/conf.d /etc/nginx/sites-available /etc/nginx/sites-enabled
+  install -m 644 "${SCRIPT_DIR}/nginx/zzz-ssd-timeout.conf" "${NGINX_TIMEOUT_FILE}"
+  sed "s#__SERVER_NAME__#${NGINX_SERVER_NAME}#g" "${SCRIPT_DIR}/nginx/site.conf.template" > "${NGINX_SITE_AVAILABLE}"
+  ln -sfn "${NGINX_SITE_AVAILABLE}" "${NGINX_SITE_ENABLED}"
+
+  if [[ ! -f "${NGINX_UPSTREAM_FILE}" ]]; then
+    cat > "${NGINX_UPSTREAM_FILE}" <<EOF_UPSTREAM
+upstream ssd_backend {
+    server 127.0.0.1:8080;
+    keepalive 32;
+}
+EOF_UPSTREAM
+  fi
+
+  nginx -t
+  systemctl reload nginx
+else
+  echo "[ERROR] nginx is not installed" >&2
+  exit 1
+fi
+
+echo "[INFO] Infra install complete"

--- a/deploy/ec2/nginx/site.conf.template
+++ b/deploy/ec2/nginx/site.conf.template
@@ -1,0 +1,25 @@
+server {
+    server_name __SERVER_NAME__;
+
+    location / {
+        proxy_pass http://ssd_backend;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    listen 443 ssl;
+    ssl_certificate /etc/letsencrypt/live/__SERVER_NAME__/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/__SERVER_NAME__/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+}
+
+server {
+    listen 80;
+    server_name __SERVER_NAME__;
+    return 301 https://$host$request_uri;
+}

--- a/deploy/ec2/nginx/zzz-ssd-timeout.conf
+++ b/deploy/ec2/nginx/zzz-ssd-timeout.conf
@@ -1,0 +1,4 @@
+proxy_connect_timeout 1800s;
+proxy_send_timeout 1800s;
+proxy_read_timeout 1800s;
+send_timeout 1800s;

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,6 +6,7 @@ pluginManagement {
     plugins {
         id 'org.springframework.boot' version '4.0.0'
         id 'io.spring.dependency-management' version '1.1.7'
+        id 'com.google.cloud.tools.jib' version '3.4.5'
     }
 }
 

--- a/ssd-api/build.gradle
+++ b/ssd-api/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'org.springframework.boot'
     id 'java'
     id 'jacoco'
+    id 'com.google.cloud.tools.jib'
 }
 
 dependencies {
@@ -24,6 +25,18 @@ dependencies {
 
 jacoco {
     toolVersion = '0.8.12'
+}
+
+jib {
+    from {
+        image = 'eclipse-temurin:21-jre-alpine'
+    }
+    container {
+        mainClass = 'or.hyu.ssd.SsdApplication'
+        ports = ['8080']
+        jvmFlags = ['-Duser.timezone=Asia/Seoul']
+        creationTime = 'USE_CURRENT_TIMESTAMP'
+    }
 }
 
 jacocoTestReport {


### PR DESCRIPTION
## 📣 Related Issue

- close #71
- close #42


<br><br>

## 📝 Summary

- `deploy/ec2` 아래에 docker-compose, nginx 설정, 인프라 설치 스크립트를 추가해 배포 설정을 Git으로 형상관리하도록 정리했습니다.
- 기존 `docker compose down/up` 배포를 blue/green 무중단 배포 스크립트 기반으로 교체했습니다.
- CD 워크플로우를 Jib 이미지 푸시 + 외부 `application-dev.yml` 분리 배포 구조로 리팩터링했습니다.
- 루트 `AGENTS.md`에 브랜치 명명 규칙을 `feature/#이슈번호/요약` 형식으로 명시했습니다.


<br><br>

## 🙏 Details

- 정적 인프라 파일은 `deploy/ec2/docker-compose.yml`, `deploy/ec2/nginx/site.conf.template`, `deploy/ec2/nginx/zzz-ssd-timeout.conf`로 저장소에서 관리하고, 민감한 `application-dev.yml`은 GitHub Secret에서 생성해 서버 `/opt/ssd/config/application-dev.yml`로만 배포되도록 분리했습니다.
- `deploy/ec2/install_infra.sh`는 서버에 Git 관리 대상 인프라 파일을 설치하고, redis/network를 compose로 기동하며, nginx 프록시/timeout 설정을 반영합니다.
- `deploy/ec2/blue_green_deploy.sh`는 `ssd-blue`/`ssd-green` 컨테이너를 교대로 띄운 뒤 로컬 헬스체크 성공 시 nginx upstream을 전환하고 이전 컨테이너를 정리합니다.
- `.github/workflows/develop-cd.yml`은 concurrency 제어, secret 기반 dev 설정 검증, Jib 이미지 빌드/푸시, 배포 파일 전송, 인프라 설치, blue/green 전환 순서로 재구성했습니다.
- `ssd-api/build.gradle`, `settings.gradle`에는 Jib 플러그인을 추가해 Dockerfile 없이도 SHA/develop-latest 태그 이미지를 푸시할 수 있게 했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * Blue/Green 배포 전략으로 무중단 배포 지원
  * Docker 이미지 자동 빌드 및 레지스트리 푸시
  * 배포 전 헬스 체크 및 자동 롤백 기능

* **Documentation**
  * 브랜치 네이밍 규칙 및 커밋 메시지 가이드라인 추가
  * EC2 배포 인프라 문서화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->