### PR TITLE
[FIX] develop-cd SSH 포트 2222 반영

### DIFF
--- a/.github/workflows/develop-cd.yml
+++ b/.github/workflows/develop-cd.yml
@@ -14,6 +14,8 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    env:
+      SSH_PORT: 2222
 
     steps:
       - name: 코드 가져오기
@@ -89,6 +91,7 @@ jobs:
         uses: appleboy/scp-action@v0.1.7
         with:
           host: ${{ secrets.HOST }}
+          port: ${{ env.SSH_PORT }}
           username: ubuntu
           key: ${{ secrets.KEY }}
           source: deploy/ec2
@@ -98,6 +101,7 @@ jobs:
         uses: appleboy/scp-action@v0.1.7
         with:
           host: ${{ secrets.HOST }}
+          port: ${{ env.SSH_PORT }}
           username: ubuntu
           key: ${{ secrets.KEY }}
           source: .runtime/application-dev.yml
@@ -107,6 +111,7 @@ jobs:
         uses: appleboy/ssh-action@v1.0.3
         with:
           host: ${{ secrets.HOST }}
+          port: ${{ env.SSH_PORT }}
           username: ubuntu
           key: ${{ secrets.KEY }}
           script_stop: true


### PR DESCRIPTION
## 📣 Related Issue

- close #42


<br><br>

## 📝 Summary

- `develop-cd` 워크플로우의 SCP/SSH 배포 단계를 서버 SSH 포트 `2222`로 맞췄습니다.
- 배포 액션 세 군데에서 공통 포트를 재사용하도록 `SSH_PORT` 환경변수를 추가했습니다.


<br><br>

## 🙏 Details

- 실패 원인은 서버 SSH 포트를 `2222`로 옮긴 뒤에도 `appleboy/scp-action`, `appleboy/ssh-action`이 기본 포트 `22`로 접속을 시도한 것이었습니다.
- `.github/workflows/develop-cd.yml`에 `SSH_PORT: 2222`를 추가하고, 배포 파일 전송 2단계와 원격 배포 실행 단계 모두 `port: ${{ env.SSH_PORT }}`를 사용하도록 수정했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 배포 워크플로우의 SSH 포트 구성이 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->