### PR TITLE
[FIX] blue/green 배포 네트워크 충돌 수정

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,6 @@
 /gradlew text eol=lf
+*.sh text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
 *.bat text eol=crlf
 *.jar binary

--- a/deploy/ec2/blue_green_deploy.sh
+++ b/deploy/ec2/blue_green_deploy.sh
@@ -54,6 +54,7 @@ fi
 NEXT_CONTAINER="${APP_NAME}-${NEXT_COLOR}"
 CURRENT_CONTAINER="${APP_NAME}-${CURRENT_COLOR}"
 HEALTH_URL="http://127.0.0.1:${NEXT_PORT}${HEALTH_PATH}"
+LEGACY_APP_CONTAINER_NAME="${LEGACY_APP_CONTAINER_NAME:-infra-app-1}"
 
 echo "[INFO] Current=${CURRENT_COLOR}(${CURRENT_PORT}), Next=${NEXT_COLOR}(${NEXT_PORT})"
 echo "[INFO] Pull image: ${IMAGE}"
@@ -112,6 +113,9 @@ systemctl reload nginx
 echo "${NEXT_COLOR}" > "${STATE_FILE}"
 
 docker rm -f "${CURRENT_CONTAINER}" >/dev/null 2>&1 || true
+if [[ "${LEGACY_APP_CONTAINER_NAME}" != "${NEXT_CONTAINER}" && "${LEGACY_APP_CONTAINER_NAME}" != "${CURRENT_CONTAINER}" ]]; then
+  docker rm -f "${LEGACY_APP_CONTAINER_NAME}" >/dev/null 2>&1 || true
+fi
 docker image prune -f >/dev/null 2>&1 || true
 
 echo "[INFO] Deploy success: active=${NEXT_COLOR}"

--- a/deploy/ec2/docker-compose.yml
+++ b/deploy/ec2/docker-compose.yml
@@ -14,6 +14,7 @@ services:
 
 networks:
   ssd-net:
+    external: true
     name: ssd-net
 
 volumes:

--- a/deploy/ec2/install_infra.sh
+++ b/deploy/ec2/install_infra.sh
@@ -30,7 +30,7 @@ fi
 
 if command -v docker >/dev/null 2>&1; then
   docker network inspect "${NETWORK_NAME}" >/dev/null 2>&1 || docker network create "${NETWORK_NAME}"
-  docker compose -f "${INFRA_DIR}/docker-compose.yml" up -d --remove-orphans redis
+  docker compose -f "${INFRA_DIR}/docker-compose.yml" up -d redis
 else
   echo "[ERROR] docker is not installed" >&2
   exit 1


### PR DESCRIPTION
## 📣 Related Issue

- close #42


<br><br>

## 📝 Summary

- blue/green 배포 시 compose 네트워크 충돌이 발생하지 않도록 외부 네트워크 사용으로 변경
- redis infra 기동 시 legacy app 컨테이너가 orphan 삭제로 제거되지 않도록 배포 스크립트 수정
- 초기 전환 이후 다음 배포에서도 8080 포트 충돌이 나지 않도록 legacy app 컨테이너 정리 로직 추가
- shell/yaml 라인 엔딩을 LF로 고정하도록 gitattributes 보강


<br><br>

## 🙏 Details

- `deploy/ec2/docker-compose.yml`
  - `ssd-net`을 compose 관리 네트워크가 아닌 `external` 네트워크로 선언해, blue/green 스크립트가 만든 기존 네트워크를 그대로 사용하도록 수정했습니다.
- `deploy/ec2/install_infra.sh`
  - `docker compose up -d --remove-orphans redis`에서 `--remove-orphans`를 제거했습니다.
  - 현재 compose 파일이 redis만 관리하기 때문에, 해당 옵션이 있으면 기존 `infra-app-1` 컨테이너까지 orphan으로 삭제되는 문제가 있었습니다.
- `deploy/ec2/blue_green_deploy.sh`
  - 전환 성공 후 legacy 컨테이너 `infra-app-1`을 정리하도록 보완했습니다.
  - 최초 migration 이후 다음 배포에서 `ssd-blue`가 `127.0.0.1:8080`을 바인딩할 때 기존 legacy 컨테이너와 충돌하지 않도록 했습니다.
- `.gitattributes`
  - `*.sh`, `*.yml`, `*.yaml`을 LF로 고정해 mixed line ending으로 인한 shell 문법 오류 가능성을 제거했습니다.

검증:
- `bash -n deploy/ec2/install_infra.sh`
- `bash -n deploy/ec2/blue_green_deploy.sh`
- `docker compose -f deploy/ec2/docker-compose.yml config`
- 원격 서버(`15.164.192.100:2222`)에서 수정본 `install_infra.sh` 실행 성공
- 원격 서버에서 `green -> blue` blue/green 재배포 성공
- `https://dev-api.simsaimdang.shop/swagger-ui/index.html` 응답 `HTTP/1.1 200` 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 셸 스크립트와 YAML 파일의 라인 엔딩 설정 표준화
  * 배포 스크립트 개선: Legacy 컨테이너 정리 로직 강화 및 자동 정리 옵션 최적화
  * 네트워크 구성 업데이트: 외부 관리 네트워크 설정 적용

<!-- end of auto-generated comment: release notes by coderabbit.ai -->