### PR TITLE
[FEATURE] 모니터링 툴 구축

### DIFF
--- a/.github/workflows/develop-cd.yml
+++ b/.github/workflows/develop-cd.yml
@@ -60,6 +60,7 @@ jobs:
       - name: 배포 스크립트 문법 검증
         run: |
           bash -n deploy/ec2/install_infra.sh
+          bash -n deploy/ec2/install_monitoring.sh
           bash -n deploy/ec2/blue_green_deploy.sh
 
       - name: Docker 레포지토리 이름 정규화
@@ -97,6 +98,16 @@ jobs:
           source: deploy/ec2
           target: /tmp
 
+      - name: 모니터링 파일 전송
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.HOST }}
+          port: ${{ env.SSH_PORT }}
+          username: ubuntu
+          key: ${{ secrets.KEY }}
+          source: k6/monitoring
+          target: /tmp
+
       - name: dev 설정 파일 전송
         uses: appleboy/scp-action@v0.1.7
         with:
@@ -116,7 +127,7 @@ jobs:
           key: ${{ secrets.KEY }}
           script_stop: true
           script: |
-            chmod +x /tmp/deploy/ec2/install_infra.sh /tmp/deploy/ec2/blue_green_deploy.sh
+            chmod +x /tmp/deploy/ec2/install_infra.sh /tmp/deploy/ec2/install_monitoring.sh /tmp/deploy/ec2/blue_green_deploy.sh
             export APP_NAME="ssd"
             export DOCKER_REPO="${{ env.DOCKER_REPO }}"
             export IMAGE_TAG="${{ github.sha }}"
@@ -128,4 +139,5 @@ jobs:
             export NGINX_SERVER_NAME="dev-api.simsaimdang.shop"
             export NGINX_UPSTREAM_FILE="/etc/nginx/conf.d/ssd-upstream.conf"
             sudo -E /tmp/deploy/ec2/install_infra.sh
+            sudo -E /tmp/deploy/ec2/install_monitoring.sh
             sudo -E /tmp/deploy/ec2/blue_green_deploy.sh

--- a/deploy/ec2/README.md
+++ b/deploy/ec2/README.md
@@ -7,9 +7,18 @@
 - `nginx/site.conf.template`: dev 도메인 프록시 설정 템플릿
 - `nginx/zzz-ssd-timeout.conf`: 장시간 AI 요청용 timeout 설정
 - `install_infra.sh`: 서버에 정적 인프라 파일을 설치하고 redis를 기동
+- `install_monitoring.sh`: Grafana/Prometheus/load-test 모니터링 스택 설치
 - `blue_green_deploy.sh`: blue/green 무중단 배포 스크립트
 
 ## 민감 정보 분리
 - `application-dev.yml`은 Git에 커밋하지 않습니다.
 - CI에서 secret으로 생성한 뒤 서버 `/opt/ssd/config/application-dev.yml`로 배포합니다.
 - 애플리케이션 컨테이너는 외부 설정 파일을 `/config/application-dev.yml`로 마운트해 사용합니다.
+
+## 모니터링 설정
+- 모니터링 리소스는 `k6/monitoring`에 형상관리합니다.
+- `develop-cd`는 서버 `/opt/ssd/monitoring`에 해당 파일을 설치하고 docker compose로 Grafana/Prometheus를 기동합니다.
+- 기본 접속 포트:
+  - Grafana: `3000`
+  - Prometheus: `9090`
+  - k6 Web Dashboard: `5665`

--- a/deploy/ec2/install_monitoring.sh
+++ b/deploy/ec2/install_monitoring.sh
@@ -49,8 +49,10 @@ install -m 644 "${MONITORING_SOURCE_DIR}/docker-compose.monitoring.yml" "${MONIT
 install -m 644 "${MONITORING_SOURCE_DIR}/prometheus/prometheus.yml" "${MONITORING_ROOT}/prometheus/prometheus.yml"
 install -m 644 "${MONITORING_SOURCE_DIR}/grafana/provisioning/datasources/prometheus.yml" "${MONITORING_ROOT}/grafana/provisioning/datasources/prometheus.yml"
 install -m 644 "${MONITORING_SOURCE_DIR}/grafana/provisioning/dashboards/dashboard.yml" "${MONITORING_ROOT}/grafana/provisioning/dashboards/dashboard.yml"
-install -m 644 "${MONITORING_SOURCE_DIR}/grafana/dashboards/ssd-loadtest-host-overview.json" "${MONITORING_ROOT}/grafana/dashboards/ssd-loadtest-host-overview.json"
-install -m 644 "${MONITORING_SOURCE_DIR}/grafana/dashboards/ssd-loadtest-k6-overview.json" "${MONITORING_ROOT}/grafana/dashboards/ssd-loadtest-k6-overview.json"
+find "${MONITORING_SOURCE_DIR}/grafana/dashboards" -maxdepth 1 -type f -name '*.json' -print0 | \
+  while IFS= read -r -d '' dashboard_file; do
+    install -m 644 "${dashboard_file}" "${MONITORING_ROOT}/grafana/dashboards/$(basename "${dashboard_file}")"
+  done
 
 if command -v docker >/dev/null 2>&1; then
   docker compose -f "${MONITORING_COMPOSE_FILE}" up -d

--- a/deploy/ec2/install_monitoring.sh
+++ b/deploy/ec2/install_monitoring.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_NAME="${APP_NAME:-ssd}"
+MONITORING_ROOT="${MONITORING_ROOT:-/opt/${APP_NAME}/monitoring}"
+MONITORING_COMPOSE_FILE="${MONITORING_ROOT}/docker-compose.monitoring.yml"
+GRAFANA_PORT="${GRAFANA_PORT:-3000}"
+PROMETHEUS_PORT="${PROMETHEUS_PORT:-9090}"
+K6_DASHBOARD_PORT="${K6_DASHBOARD_PORT:-5665}"
+
+resolve_monitoring_source_dir() {
+  local candidates=()
+
+  if [[ -n "${MONITORING_SOURCE_DIR:-}" ]]; then
+    candidates+=("${MONITORING_SOURCE_DIR}")
+  fi
+
+  candidates+=(
+    "${SCRIPT_DIR}/../../k6/monitoring"
+    "/tmp/k6/monitoring"
+    "/tmp/monitoring"
+  )
+
+  for candidate in "${candidates[@]}"; do
+    if [[ -d "${candidate}" ]]; then
+      printf '%s\n' "${candidate}"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+MONITORING_SOURCE_DIR="$(resolve_monitoring_source_dir || true)"
+if [[ -z "${MONITORING_SOURCE_DIR}" ]]; then
+  echo "[ERROR] monitoring source dir not found" >&2
+  exit 1
+fi
+
+install -d -m 755 \
+  "${MONITORING_ROOT}" \
+  "${MONITORING_ROOT}/prometheus" \
+  "${MONITORING_ROOT}/grafana/provisioning/datasources" \
+  "${MONITORING_ROOT}/grafana/provisioning/dashboards" \
+  "${MONITORING_ROOT}/grafana/dashboards"
+
+install -m 644 "${MONITORING_SOURCE_DIR}/docker-compose.monitoring.yml" "${MONITORING_COMPOSE_FILE}"
+install -m 644 "${MONITORING_SOURCE_DIR}/prometheus/prometheus.yml" "${MONITORING_ROOT}/prometheus/prometheus.yml"
+install -m 644 "${MONITORING_SOURCE_DIR}/grafana/provisioning/datasources/prometheus.yml" "${MONITORING_ROOT}/grafana/provisioning/datasources/prometheus.yml"
+install -m 644 "${MONITORING_SOURCE_DIR}/grafana/provisioning/dashboards/dashboard.yml" "${MONITORING_ROOT}/grafana/provisioning/dashboards/dashboard.yml"
+install -m 644 "${MONITORING_SOURCE_DIR}/grafana/dashboards/ssd-loadtest-host-overview.json" "${MONITORING_ROOT}/grafana/dashboards/ssd-loadtest-host-overview.json"
+install -m 644 "${MONITORING_SOURCE_DIR}/grafana/dashboards/ssd-loadtest-k6-overview.json" "${MONITORING_ROOT}/grafana/dashboards/ssd-loadtest-k6-overview.json"
+
+if command -v docker >/dev/null 2>&1; then
+  docker compose -f "${MONITORING_COMPOSE_FILE}" up -d
+else
+  echo "[ERROR] docker is not installed" >&2
+  exit 1
+fi
+
+if command -v ufw >/dev/null 2>&1; then
+  if ufw status | grep -q "Status: active"; then
+    ufw allow "${GRAFANA_PORT}/tcp" >/dev/null 2>&1 || true
+    ufw allow "${PROMETHEUS_PORT}/tcp" >/dev/null 2>&1 || true
+    ufw allow "${K6_DASHBOARD_PORT}/tcp" >/dev/null 2>&1 || true
+  fi
+fi
+
+echo "[INFO] Monitoring install complete"
+echo "[INFO] Grafana:    http://<server>:${GRAFANA_PORT}"
+echo "[INFO] Prometheus: http://<server>:${PROMETHEUS_PORT}"
+echo "[INFO] k6 Web UI:  http://<server>:${K6_DASHBOARD_PORT}"

--- a/k6/README.md
+++ b/k6/README.md
@@ -13,6 +13,7 @@
 - `k6/monitoring/grafana/dashboards`
   - 호스트/컨테이너 모니터링 대시보드
   - k6 메트릭 대시보드
+  - JVM 메트릭 대시보드
 
 ## 서버 설치
 `develop-cd`에서 `deploy/ec2/install_monitoring.sh`가 실행되면 자동으로 설치됩니다.
@@ -27,6 +28,16 @@ sudo /tmp/deploy/ec2/install_monitoring.sh
 - Grafana: `http://<SERVER_IP>:3000`
 - Prometheus: `http://<SERVER_IP>:9090`
 - k6 Web Dashboard: `http://<SERVER_IP>:5665`
+
+## JVM 메트릭
+- SSD 애플리케이션은 `/actuator/prometheus`를 공개해 Prometheus가 JVM 메트릭을 수집합니다.
+- Grafana의 `SSD Load Test JVM Overview` 대시보드에서 아래 항목을 확인할 수 있습니다.
+  - JVM Up
+  - Process Uptime
+  - Heap / Non-heap Memory
+  - Live / Daemon / Peak Threads
+  - GC Activity
+  - HikariCP Connections
 
 ## k6 메트릭을 Prometheus로 보내는 방법
 Prometheus는 remote write receiver를 활성화해 두었습니다.

--- a/k6/README.md
+++ b/k6/README.md
@@ -1,0 +1,46 @@
+# SSD k6 / Monitoring Bootstrap
+
+## 목적
+- SSD 부하테스트를 위한 모니터링 스택을 동일 서버에 구성합니다.
+- Grafana/Prometheus는 서버 주소로 직접 접근하고, k6 web dashboard도 서버 포트로 직접 접근합니다.
+
+## 포함 구성
+- `k6/monitoring/docker-compose.monitoring.yml`
+  - Prometheus
+  - Grafana
+  - node-exporter
+  - cadvisor
+- `k6/monitoring/grafana/dashboards`
+  - 호스트/컨테이너 모니터링 대시보드
+  - k6 메트릭 대시보드
+
+## 서버 설치
+`develop-cd`에서 `deploy/ec2/install_monitoring.sh`가 실행되면 자동으로 설치됩니다.
+
+직접 설치가 필요하면 서버에서 아래를 실행합니다.
+
+```bash
+sudo /tmp/deploy/ec2/install_monitoring.sh
+```
+
+## 접속 주소
+- Grafana: `http://<SERVER_IP>:3000`
+- Prometheus: `http://<SERVER_IP>:9090`
+- k6 Web Dashboard: `http://<SERVER_IP>:5665`
+
+## k6 메트릭을 Prometheus로 보내는 방법
+Prometheus는 remote write receiver를 활성화해 두었습니다.
+
+```bash
+K6_PROMETHEUS_RW_SERVER_URL=http://<SERVER_IP>:9090/api/v1/write \
+K6_PROMETHEUS_RW_TREND_STATS=p(95),p(99),avg,max \
+K6_WEB_DASHBOARD=true \
+K6_WEB_DASHBOARD_HOST=0.0.0.0 \
+K6_WEB_DASHBOARD_PORT=5665 \
+k6 run -o experimental-prometheus-rw <scenario.js>
+```
+
+## 참고 사항
+- `5665/tcp`, `3000/tcp`, `9090/tcp`는 서버 `ufw`에서 허용합니다.
+- 외부에서 직접 접속하려면 AWS Security Group도 동일 포트를 열어야 합니다.
+- SSD 애플리케이션 메트릭(`/actuator/prometheus`)은 아직 포함하지 않았습니다. 해당 엔드포인트를 노출하면 Prometheus scrape job만 추가하면 됩니다.

--- a/k6/monitoring/docker-compose.monitoring.yml
+++ b/k6/monitoring/docker-compose.monitoring.yml
@@ -1,0 +1,77 @@
+name: ssd-loadtest-monitoring
+
+services:
+  prometheus:
+    image: prom/prometheus:v2.54.1
+    container_name: ssd-loadtest-prometheus
+    restart: unless-stopped
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.retention.time=24h
+      - --web.enable-lifecycle
+      - --web.enable-remote-write-receiver
+    ports:
+      - "9090:9090"
+    extra_hosts:
+      - host.docker.internal:host-gateway
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    networks:
+      - monitoring
+
+  grafana:
+    image: grafana/grafana:11.1.4
+    container_name: ssd-loadtest-grafana
+    restart: unless-stopped
+    depends_on:
+      - prometheus
+    environment:
+      GF_USERS_ALLOW_SIGN_UP: "false"
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Viewer
+      GF_AUTH_DISABLE_LOGIN_FORM: "true"
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+      - grafana_data:/var/lib/grafana
+    networks:
+      - monitoring
+
+  node-exporter:
+    image: prom/node-exporter:v1.8.2
+    container_name: ssd-loadtest-node-exporter
+    restart: unless-stopped
+    command:
+      - --path.rootfs=/host
+    pid: host
+    volumes:
+      - /:/host:ro,rslave
+    networks:
+      - monitoring
+
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:v0.49.1
+    container_name: ssd-loadtest-cadvisor
+    restart: unless-stopped
+    privileged: true
+    devices:
+      - /dev/kmsg:/dev/kmsg
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker:/var/lib/docker:ro
+      - /dev/disk:/dev/disk:ro
+    networks:
+      - monitoring
+
+networks:
+  monitoring:
+    name: ssd-loadtest-monitoring
+
+volumes:
+  prometheus_data:
+  grafana_data:

--- a/k6/monitoring/grafana/dashboards/ssd-loadtest-host-overview.json
+++ b/k6/monitoring/grafana/dashboards/ssd-loadtest-host-overview.json
@@ -1,0 +1,83 @@
+{
+  "annotations": {"list": []},
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "percent"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 0},
+      "id": 1,
+      "options": {"legend": {"displayMode": "list", "placement": "bottom"}, "tooltip": {"mode": "single"}},
+      "targets": [{"expr": "100 - (avg(rate(node_cpu_seconds_total{mode=\"idle\"}[2m])) * 100)", "legendFormat": "host cpu", "refId": "A"}],
+      "title": "Host CPU Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "percent"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 0},
+      "id": 2,
+      "options": {"legend": {"displayMode": "list", "placement": "bottom"}, "tooltip": {"mode": "single"}},
+      "targets": [{"expr": "(1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)) * 100", "legendFormat": "host memory used", "refId": "A"}],
+      "title": "Host Memory Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "percent"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 0},
+      "id": 3,
+      "options": {"legend": {"displayMode": "list", "placement": "bottom"}, "tooltip": {"mode": "single"}},
+      "targets": [{"expr": "100 * (1 - (node_filesystem_avail_bytes{mountpoint=\"/\",fstype!~\"tmpfs|overlay\"} / node_filesystem_size_bytes{mountpoint=\"/\",fstype!~\"tmpfs|overlay\"}))", "legendFormat": "root fs used", "refId": "A"}],
+      "title": "Root Filesystem Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "percentunit"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 8},
+      "id": 4,
+      "options": {"legend": {"displayMode": "list", "placement": "bottom"}, "tooltip": {"mode": "single"}},
+      "targets": [{"expr": "sum by (name) (rate(container_cpu_usage_seconds_total{name=~\"ssd-(blue|green)|infra-redis-1|ssd-loadtest-(prometheus|grafana|node-exporter|cadvisor)\"}[2m]))", "legendFormat": "{{name}}", "refId": "A"}],
+      "title": "Container CPU Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "bytes"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 8},
+      "id": 5,
+      "options": {"legend": {"displayMode": "list", "placement": "bottom"}, "tooltip": {"mode": "single"}},
+      "targets": [{"expr": "container_memory_working_set_bytes{name=~\"ssd-(blue|green)|infra-redis-1|ssd-loadtest-(prometheus|grafana|node-exporter|cadvisor)\"}", "legendFormat": "{{name}}", "refId": "A"}],
+      "title": "Container Memory Working Set",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "Bps"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 16},
+      "id": 6,
+      "options": {"legend": {"displayMode": "list", "placement": "bottom"}, "tooltip": {"mode": "single"}},
+      "targets": [
+        {"expr": "sum by (device) (rate(node_network_receive_bytes_total{device!~\"lo\"}[2m]))", "legendFormat": "rx {{device}}", "refId": "A"},
+        {"expr": "sum by (device) (rate(node_network_transmit_bytes_total{device!~\"lo\"}[2m]))", "legendFormat": "tx {{device}}", "refId": "B"}
+      ],
+      "title": "Host Network Throughput",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": ["ssd", "loadtest", "host"],
+  "templating": {"list": []},
+  "time": {"from": "now-30m", "to": "now"},
+  "timezone": "browser",
+  "title": "SSD Load Test Host Overview",
+  "uid": "ssd-loadtest-host-overview",
+  "version": 1,
+  "weekStart": ""
+}

--- a/k6/monitoring/grafana/dashboards/ssd-loadtest-jvm-overview.json
+++ b/k6/monitoring/grafana/dashboards/ssd-loadtest-jvm-overview.json
@@ -1,0 +1,115 @@
+{
+  "annotations": {"list": []},
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"mappings": [], "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": 0}, {"color": "green", "value": 1}]}}, "overrides": []},
+      "gridPos": {"h": 5, "w": 6, "x": 0, "y": 0},
+      "id": 1,
+      "options": {"colorMode": "background", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "value_and_name"},
+      "targets": [{"expr": "max(up{job=\"ssd-app\"})", "refId": "A"}],
+      "title": "JVM Up",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
+      "gridPos": {"h": 5, "w": 6, "x": 6, "y": 0},
+      "id": 2,
+      "options": {"colorMode": "value", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "value_and_name"},
+      "targets": [{"expr": "max(process_uptime_seconds{job=\"ssd-app\"})", "refId": "A"}],
+      "title": "Process Uptime",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "bytes"}, "overrides": []},
+      "gridPos": {"h": 5, "w": 6, "x": 12, "y": 0},
+      "id": 3,
+      "options": {"colorMode": "value", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "value_and_name"},
+      "targets": [{"expr": "sum(jvm_memory_used_bytes{job=\"ssd-app\",area=\"heap\"})", "refId": "A"}],
+      "title": "Heap Used",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "none"}, "overrides": []},
+      "gridPos": {"h": 5, "w": 6, "x": 18, "y": 0},
+      "id": 4,
+      "options": {"colorMode": "value", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "value_and_name"},
+      "targets": [{"expr": "max(jvm_threads_live_threads{job=\"ssd-app\"})", "refId": "A"}],
+      "title": "Live Threads",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "bytes"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 5},
+      "id": 5,
+      "options": {"legend": {"displayMode": "list", "placement": "bottom"}, "tooltip": {"mode": "single"}},
+      "targets": [
+        {"expr": "sum(jvm_memory_used_bytes{job=\"ssd-app\",area=\"heap\"})", "legendFormat": "heap used", "refId": "A"},
+        {"expr": "sum(jvm_memory_max_bytes{job=\"ssd-app\",area=\"heap\"})", "legendFormat": "heap max", "refId": "B"},
+        {"expr": "sum(jvm_memory_used_bytes{job=\"ssd-app\",area=\"nonheap\"})", "legendFormat": "non-heap used", "refId": "C"}
+      ],
+      "title": "JVM Memory",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "none"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 5},
+      "id": 6,
+      "options": {"legend": {"displayMode": "list", "placement": "bottom"}, "tooltip": {"mode": "single"}},
+      "targets": [
+        {"expr": "max(jvm_threads_live_threads{job=\"ssd-app\"})", "legendFormat": "live", "refId": "A"},
+        {"expr": "max(jvm_threads_daemon_threads{job=\"ssd-app\"})", "legendFormat": "daemon", "refId": "B"},
+        {"expr": "max(jvm_threads_peak_threads{job=\"ssd-app\"})", "legendFormat": "peak", "refId": "C"}
+      ],
+      "title": "JVM Threads",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "ops"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 13},
+      "id": 7,
+      "options": {"legend": {"displayMode": "list", "placement": "bottom"}, "tooltip": {"mode": "single"}},
+      "targets": [
+        {"expr": "sum(rate(jvm_gc_pause_seconds_count{job=\"ssd-app\"}[5m]))", "legendFormat": "gc pause count/sec", "refId": "A"},
+        {"expr": "sum(rate(jvm_gc_pause_seconds_sum{job=\"ssd-app\"}[5m]))", "legendFormat": "gc pause sec/sec", "refId": "B"}
+      ],
+      "title": "JVM GC Activity",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "none"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 13},
+      "id": 8,
+      "options": {"legend": {"displayMode": "list", "placement": "bottom"}, "tooltip": {"mode": "single"}},
+      "targets": [
+        {"expr": "max(hikaricp_connections_active{job=\"ssd-app\"})", "legendFormat": "active", "refId": "A"},
+        {"expr": "max(hikaricp_connections_idle{job=\"ssd-app\"})", "legendFormat": "idle", "refId": "B"},
+        {"expr": "max(hikaricp_connections_pending{job=\"ssd-app\"})", "legendFormat": "pending", "refId": "C"}
+      ],
+      "title": "HikariCP",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": ["ssd", "loadtest", "jvm"],
+  "templating": {"list": []},
+  "time": {"from": "now-30m", "to": "now"},
+  "timezone": "browser",
+  "title": "SSD Load Test JVM Overview",
+  "uid": "ssd-loadtest-jvm-overview",
+  "version": 1,
+  "weekStart": ""
+}

--- a/k6/monitoring/grafana/dashboards/ssd-loadtest-k6-overview.json
+++ b/k6/monitoring/grafana/dashboards/ssd-loadtest-k6-overview.json
@@ -1,0 +1,86 @@
+{
+  "annotations": {"list": []},
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "none"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 0},
+      "id": 1,
+      "options": {"legend": {"displayMode": "list", "placement": "bottom"}, "tooltip": {"mode": "single"}},
+      "targets": [{"expr": "sum by (scenario) (k6_vus)", "legendFormat": "{{scenario}}", "refId": "A"}],
+      "title": "Active VUs",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "reqps"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 0},
+      "id": 2,
+      "options": {"legend": {"displayMode": "list", "placement": "bottom"}, "tooltip": {"mode": "single"}},
+      "targets": [{"expr": "sum by (scenario) (rate(k6_http_reqs_total[1m]))", "legendFormat": "{{scenario}}", "refId": "A"}],
+      "title": "HTTP Requests / sec",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "percentunit"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 0},
+      "id": 3,
+      "options": {"legend": {"displayMode": "list", "placement": "bottom"}, "tooltip": {"mode": "single"}},
+      "targets": [{"expr": "avg by (scenario) (k6_http_req_failed_rate)", "legendFormat": "{{scenario}}", "refId": "A"}],
+      "title": "HTTP Failure Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 8},
+      "id": 4,
+      "options": {"legend": {"displayMode": "list", "placement": "bottom"}, "tooltip": {"mode": "single"}},
+      "targets": [
+        {"expr": "avg by (scenario) (k6_http_req_duration_p95)", "legendFormat": "p95 {{scenario}}", "refId": "A"},
+        {"expr": "avg by (scenario) (k6_http_req_duration_p99)", "legendFormat": "p99 {{scenario}}", "refId": "B"}
+      ],
+      "title": "HTTP Request Duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 8},
+      "id": 5,
+      "options": {"legend": {"displayMode": "list", "placement": "bottom"}, "tooltip": {"mode": "single"}},
+      "targets": [
+        {"expr": "avg by (scenario) (k6_iteration_duration_avg)", "legendFormat": "avg {{scenario}}", "refId": "A"},
+        {"expr": "avg by (scenario) (k6_iteration_duration_p95)", "legendFormat": "p95 {{scenario}}", "refId": "B"}
+      ],
+      "title": "Iteration Duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "ops"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 16},
+      "id": 6,
+      "options": {"legend": {"displayMode": "list", "placement": "bottom"}, "tooltip": {"mode": "single"}},
+      "targets": [{"expr": "sum by (scenario) (rate(k6_iterations_total[1m]))", "legendFormat": "{{scenario}}", "refId": "A"}],
+      "title": "Iterations / sec",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": ["ssd", "loadtest", "k6"],
+  "templating": {"list": []},
+  "time": {"from": "now-30m", "to": "now"},
+  "timezone": "browser",
+  "title": "SSD Load Test k6 Overview",
+  "uid": "ssd-loadtest-k6-overview",
+  "version": 1,
+  "weekStart": ""
+}

--- a/k6/monitoring/grafana/provisioning/dashboards/dashboard.yml
+++ b/k6/monitoring/grafana/provisioning/dashboards/dashboard.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: SSD Load Test Dashboards
+    orgId: 1
+    folder: SSD Load Test
+    type: file
+    disableDeletion: false
+    allowUiUpdates: false
+    options:
+      path: /var/lib/grafana/dashboards

--- a/k6/monitoring/grafana/provisioning/datasources/prometheus.yml
+++ b/k6/monitoring/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - uid: prometheus
+    name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/k6/monitoring/prometheus/prometheus.yml
+++ b/k6/monitoring/prometheus/prometheus.yml
@@ -11,8 +11,8 @@ scrape_configs:
     static_configs:
       - targets: ['cadvisor:8080']
 
-  # SSD 애플리케이션이 actuator/prometheus를 노출하면 아래 job을 활성화한다.
-  # - job_name: ssd-app
-  #   metrics_path: /actuator/prometheus
-  #   static_configs:
-  #     - targets: ['host.docker.internal:8080']
+  - job_name: ssd-app
+    metrics_path: /actuator/prometheus
+    scheme: https
+    static_configs:
+      - targets: ['dev-api.simsaimdang.shop']

--- a/k6/monitoring/prometheus/prometheus.yml
+++ b/k6/monitoring/prometheus/prometheus.yml
@@ -1,0 +1,18 @@
+global:
+  scrape_interval: 5s
+  evaluation_interval: 5s
+
+scrape_configs:
+  - job_name: node-exporter
+    static_configs:
+      - targets: ['node-exporter:9100']
+
+  - job_name: cadvisor
+    static_configs:
+      - targets: ['cadvisor:8080']
+
+  # SSD 애플리케이션이 actuator/prometheus를 노출하면 아래 job을 활성화한다.
+  # - job_name: ssd-app
+  #   metrics_path: /actuator/prometheus
+  #   static_configs:
+  #     - targets: ['host.docker.internal:8080']

--- a/ssd-api/build.gradle
+++ b/ssd-api/build.gradle
@@ -10,9 +10,11 @@ dependencies {
     implementation project(':ssd-core')
     implementation project(':ssd-infra')
 
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.0'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 

--- a/ssd-api/src/main/java/or/hyu/ssd/global/config/SecurityConfig.java
+++ b/ssd-api/src/main/java/or/hyu/ssd/global/config/SecurityConfig.java
@@ -94,6 +94,7 @@ public class SecurityConfig {
         // 인가 경로 설정
         http.authorizeHttpRequests((auth)->auth
                 .requestMatchers(WhiteListConfig.swaggerWhitelist().toArray(new String[0])).permitAll()
+                .requestMatchers(WhiteListConfig.actuatorWhitelist().toArray(new String[0])).permitAll()
                 .requestMatchers(WhiteListConfig.oauthWhitelist().toArray(new String[0])).permitAll()
                 .anyRequest().authenticated());
 

--- a/ssd-api/src/main/resources/application.yml
+++ b/ssd-api/src/main/resources/application.yml
@@ -90,6 +90,19 @@ app:
       system: ${EVAL_CHECK_SYS_PROMPT}
       user: ${EVAL_CHECK_USER_PROMPT}
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,prometheus
+  endpoint:
+    health:
+      probes:
+        enabled: true
+  metrics:
+    tags:
+      application: ${spring.application.name}
+
 ---
 spring:
   ai:

--- a/ssd-api/src/test/java/or/hyu/ssd/global/config/properties/WhiteListConfigTest.java
+++ b/ssd-api/src/test/java/or/hyu/ssd/global/config/properties/WhiteListConfigTest.java
@@ -1,0 +1,16 @@
+package or.hyu.ssd.global.config.properties;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WhiteListConfigTest {
+
+    @Test
+    @DisplayName("actuatorWhitelist()는 프로메테우스와 헬스 엔드포인트를 포함한다")
+    void actuatorWhitelist_containsMonitoringEndpoints() {
+        assertThat(WhiteListConfig.actuatorWhitelist())
+                .contains("/actuator/prometheus", "/actuator/health", "/actuator/health/**");
+    }
+}

--- a/ssd-core/src/main/java/or/hyu/ssd/global/config/properties/WhiteListConfig.java
+++ b/ssd-core/src/main/java/or/hyu/ssd/global/config/properties/WhiteListConfig.java
@@ -17,6 +17,14 @@ public class WhiteListConfig {
         );
     }
 
+    public static final List<String> actuatorWhitelist() {
+        return List.of(
+                "/actuator/prometheus",
+                "/actuator/health",
+                "/actuator/health/**"
+        );
+    }
+
     // oauth 관련 인가 설정
     public static final List<String> oauthWhitelist() {
         return List.of(


### PR DESCRIPTION
## 📣 Related Issue

- close #77


<br><br>

## 📝 Summary

- k6 부하테스트용 Grafana/Prometheus 모니터링 스택을 레포에 추가했습니다.
- same server에서 바로 접근 가능한 포트 기반 모니터링 구성을 만들고 `develop-cd`에 자동 설치 단계를 연결했습니다.
- 호스트/컨테이너 지표와 k6 지표를 볼 수 있는 Grafana 대시보드를 provisioning 방식으로 포함했습니다.

```
node-exporter를 통해 서버 자원에 대한 메트릭을 수집
cadvisor를 통해 도커 컨테이너에 대한 메트릭을 수집
spring actuator를 통해 JVM에 대한 메트릭을 수집
-> 이를 prometheus가 수집하여 grafana로 대시보드에 시분할 그래프로 표현합니다.

```

<br><br>

## 🙏 Details

- `k6/monitoring`
  - `docker-compose.monitoring.yml`로 Prometheus, Grafana, node-exporter, cadvisor를 함께 기동하도록 구성했습니다.
  - Prometheus는 `--web.enable-remote-write-receiver`를 활성화해 향후 k6가 `experimental-prometheus-rw` 출력으로 메트릭을 직접 적재할 수 있도록 했습니다.
  - Grafana는 provisioning 기반으로 Prometheus datasource와 대시보드 2종을 자동 등록하도록 구성했습니다.
- `deploy/ec2/install_monitoring.sh`
  - 모니터링 설정 파일을 `/opt/ssd/monitoring`에 설치하고 docker compose로 스택을 기동하도록 구현했습니다.
  - `scp-action` 경로와 수동 `scp` 경로 차이를 모두 흡수하도록 monitoring source 경로 탐색 로직을 넣었습니다.
  - `ufw`가 active인 경우 `3000/tcp`, `9090/tcp`, `5665/tcp`를 허용해 Grafana, Prometheus, k6 dashboard를 서버 주소로 직접 접근할 수 있게 했습니다.
- `.github/workflows/develop-cd.yml`
  - 배포 시 모니터링 리소스(`k6/monitoring`)도 함께 전송하고 `install_monitoring.sh`를 실행하도록 연결했습니다.
  - 스크립트 문법 검증 단계에 `install_monitoring.sh`를 추가했습니다.
- `k6/README.md`
  - direct URL, Prometheus remote write, k6 web dashboard 실행 예시를 정리했습니다.

검증:
- `bash -n deploy/ec2/install_monitoring.sh`
- `docker compose -f k6/monitoring/docker-compose.monitoring.yml config`
- `jq empty k6/monitoring/grafana/dashboards/*.json`
- dev 서버(`15.164.192.100:2222`)에 직접 설치 후 확인
  - `http://15.164.192.100:3000/login` -> `HTTP/1.1 200 OK`
  - `http://15.164.192.100:9090/-/ready` -> `HTTP/1.1 200 OK`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 통합 모니터링 스택 추가 (Prometheus, Grafana, Node Exporter, cAdvisor) 및 관련 대시보드(호스트, k6, JVM)
  * 자동화된 서버 설치/배포 단계에 모니터링 설치 포함 및 배포 시 서비스 기동 자동화
  * 애플리케이션 메트릭 노출(Actuator/Prometheus) 설정 추가

* **설명서**
  * 모니터링 설치·접근 안내, 기본 포트(Grafana 3000, Prometheus 9090, k6 5665) 및 방화벽 참고 문서 추가

* **테스트**
  * 화이트리스트 관련 단위 테스트 추가 (모니터링 엔드포인트 포함)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->