### PR TITLE
[CHORE] Sentry 에러로그 수집 기능 구현

### DIFF
--- a/ssd-api/build.gradle
+++ b/ssd-api/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.0'
+    implementation 'io.sentry:sentry-spring-boot-starter-jakarta:7.9.0'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 
     runtimeOnly 'org.postgresql:postgresql'

--- a/ssd-api/src/main/resources/application.yml
+++ b/ssd-api/src/main/resources/application.yml
@@ -90,6 +90,16 @@ app:
       system: ${EVAL_CHECK_SYS_PROMPT}
       user: ${EVAL_CHECK_USER_PROMPT}
 
+discord:
+  webhook-url: ${DISCORD_WEBHOOK_URL:}
+
+sentry:
+  dsn: ${SENTRY_DSN:}
+  exception-resolver-order: -2147483647
+  max-request-body-size: always
+  send-default-pii: true
+  environment: ${SENTRY_ENVIRONMENT:${spring.application.name}}
+
 management:
   endpoints:
     web:

--- a/ssd-core/build.gradle
+++ b/ssd-core/build.gradle
@@ -7,6 +7,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'io.sentry:sentry:7.9.0'
 
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
     implementation 'io.github.openfeign:feign-jackson:13.6'
@@ -16,4 +17,6 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/ssd-core/src/main/java/or/hyu/ssd/global/alert/ErrorAlertContext.java
+++ b/ssd-core/src/main/java/or/hyu/ssd/global/alert/ErrorAlertContext.java
@@ -1,0 +1,38 @@
+package or.hyu.ssd.global.alert;
+
+import or.hyu.ssd.global.api.ErrorCode;
+
+public record ErrorAlertContext(
+        String method,
+        String uri,
+        String clientIp,
+        String errorCode,
+        int status,
+        String exceptionClass,
+        String message
+) {
+    public static ErrorAlertContext of(
+            String method,
+            String uri,
+            String clientIp,
+            ErrorCode errorCode,
+            Throwable throwable
+    ) {
+        return new ErrorAlertContext(
+                method,
+                uri,
+                clientIp,
+                errorCode.getCode(),
+                errorCode.getStatus().value(),
+                throwable == null ? "(unknown)" : throwable.getClass().getSimpleName(),
+                throwable == null ? "(omitted)" : safeMessage(throwable.getMessage())
+        );
+    }
+
+    private static String safeMessage(String message) {
+        if (message == null || message.isBlank()) {
+            return "(omitted)";
+        }
+        return message.replaceAll("[\\r\\n\\t]+", " ").trim();
+    }
+}

--- a/ssd-core/src/main/java/or/hyu/ssd/global/alert/ErrorAlertNotifier.java
+++ b/ssd-core/src/main/java/or/hyu/ssd/global/alert/ErrorAlertNotifier.java
@@ -1,0 +1,5 @@
+package or.hyu.ssd.global.alert;
+
+public interface ErrorAlertNotifier {
+    void notify(ErrorAlertContext context);
+}

--- a/ssd-core/src/main/java/or/hyu/ssd/global/api/GlobalExceptionHandler.java
+++ b/ssd-core/src/main/java/or/hyu/ssd/global/api/GlobalExceptionHandler.java
@@ -1,7 +1,12 @@
 package or.hyu.ssd.global.api;
 
 
+import io.sentry.Sentry;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import or.hyu.ssd.global.alert.ErrorAlertContext;
+import or.hyu.ssd.global.alert.ErrorAlertNotifier;
 import or.hyu.ssd.global.api.handler.CustomException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -11,56 +16,96 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
+import java.util.List;
+
 @RestControllerAdvice
 @Slf4j
+@RequiredArgsConstructor
 public class GlobalExceptionHandler {
 
+    private final List<ErrorAlertNotifier> errorAlertNotifiers;
+
     @ExceptionHandler(CustomException.class)
-    public ResponseEntity<ApiResponse<Void>> handleGeneralException(CustomException e) {
+    public ResponseEntity<ApiResponse<Void>> handleGeneralException(CustomException e, HttpServletRequest request) {
         ErrorCode errorCode = e.getErrorCode();
         log.warn("Handled CustomException: {} - {}", errorCode.getCode(), errorCode.getMessage(), e);
+        captureAndNotify(e, errorCode, request);
         ApiResponse<Void> response = ApiResponse.fail(errorCode);
 
         return ResponseEntity.status(errorCode.getStatus()).body(response);
     }
 
     @ExceptionHandler(NoHandlerFoundException.class)
-    public ResponseEntity<ApiResponse<Void>> handleNotFound(NoHandlerFoundException e) {
+    public ResponseEntity<ApiResponse<Void>> handleNotFound(NoHandlerFoundException e, HttpServletRequest request) {
         ErrorCode errorCode = ErrorCode.REQUEST_API_NOT_FOUND;
         log.warn("API not found: {} {}", e.getHttpMethod(), e.getRequestURL());
+        captureAndNotify(e, errorCode, request);
         return ResponseEntity.status(errorCode.getStatus())
                 .body(ApiResponse.fail(errorCode));
     }
 
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
-    public ResponseEntity<ApiResponse<Void>> handleMethodNotAllowed(HttpRequestMethodNotSupportedException e) {
+    public ResponseEntity<ApiResponse<Void>> handleMethodNotAllowed(HttpRequestMethodNotSupportedException e, HttpServletRequest request) {
         ErrorCode errorCode = ErrorCode.REQUEST_METHOD_NOT_ALLOWED;
         log.warn("Method not allowed: {}", e.getMessage());
+        captureAndNotify(e, errorCode, request);
         return ResponseEntity.status(errorCode.getStatus())
                 .body(ApiResponse.fail(errorCode));
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ApiResponse<Void>> handleUnhandledException(Exception e) {
+    public ResponseEntity<ApiResponse<Void>> handleUnhandledException(Exception e, HttpServletRequest request) {
         ErrorCode errorCode = ErrorCode.SERVER_EXCEPTION;
         log.error("Unhandled exception", e);
+        captureAndNotify(e, errorCode, request);
         return ResponseEntity.status(errorCode.getStatus())
                 .body(ApiResponse.fail(errorCode));
     }
 
     @ExceptionHandler(ObjectOptimisticLockingFailureException.class)
-    public ResponseEntity<ApiResponse<Void>> handleOptimisticLock(ObjectOptimisticLockingFailureException e) {
+    public ResponseEntity<ApiResponse<Void>> handleOptimisticLock(ObjectOptimisticLockingFailureException e, HttpServletRequest request) {
         ErrorCode errorCode = ErrorCode.CHECKLIST_CONFLICT;
         log.warn("Optimistic locking failure: {}", e.getMessage());
+        captureAndNotify(e, errorCode, request);
         return ResponseEntity.status(errorCode.getStatus())
                 .body(ApiResponse.fail(errorCode));
     }
 
     @ExceptionHandler(HttpMessageNotReadableException.class)
-    public ResponseEntity<ApiResponse<Void>> handleNotReadable(HttpMessageNotReadableException e) {
+    public ResponseEntity<ApiResponse<Void>> handleNotReadable(HttpMessageNotReadableException e, HttpServletRequest request) {
         ErrorCode errorCode = ErrorCode.REQUEST_BODY_INVALID_JSON;
         log.warn("JSON parse error: {}", e.getMessage());
+        captureAndNotify(e, errorCode, request);
         return ResponseEntity.status(errorCode.getStatus())
                 .body(ApiResponse.fail(errorCode));
+    }
+
+    private void captureAndNotify(Throwable throwable, ErrorCode errorCode, HttpServletRequest request) {
+        Sentry.captureException(throwable);
+
+        if (!isServerError(errorCode)) {
+            return;
+        }
+
+        ErrorAlertContext context = ErrorAlertContext.of(
+                request.getMethod(),
+                request.getRequestURI(),
+                resolveClientIp(request),
+                errorCode,
+                throwable
+        );
+        errorAlertNotifiers.forEach(notifier -> notifier.notify(context));
+    }
+
+    private boolean isServerError(ErrorCode errorCode) {
+        return errorCode.getStatus().is5xxServerError();
+    }
+
+    private String resolveClientIp(HttpServletRequest request) {
+        String forwardedFor = request.getHeader("X-Forwarded-For");
+        if (forwardedFor != null && !forwardedFor.isBlank()) {
+            return forwardedFor.split(",")[0].trim();
+        }
+        return request.getRemoteAddr();
     }
 }

--- a/ssd-core/src/main/java/or/hyu/ssd/global/config/properties/DiscordProperties.java
+++ b/ssd-core/src/main/java/or/hyu/ssd/global/config/properties/DiscordProperties.java
@@ -1,0 +1,18 @@
+package or.hyu.ssd.global.config.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "discord")
+public class DiscordProperties {
+    private String webhookUrl;
+
+    public boolean hasWebhookUrl() {
+        return webhookUrl != null && !webhookUrl.isBlank();
+    }
+}

--- a/ssd-core/src/test/java/or/hyu/ssd/global/api/GlobalExceptionHandlerTest.java
+++ b/ssd-core/src/test/java/or/hyu/ssd/global/api/GlobalExceptionHandlerTest.java
@@ -1,0 +1,58 @@
+package or.hyu.ssd.global.api;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import or.hyu.ssd.global.alert.ErrorAlertContext;
+import or.hyu.ssd.global.alert.ErrorAlertNotifier;
+import or.hyu.ssd.global.api.handler.UserExceptionHandler;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.servlet.NoHandlerFoundException;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class GlobalExceptionHandlerTest {
+
+    @Mock
+    private ErrorAlertNotifier errorAlertNotifier;
+
+    @Test
+    @DisplayName("handleGeneralException()는 5xx CustomException에서 Discord 알림을 보낸다")
+    void handleGeneralException_notifiesDiscordForServerErrors() {
+        GlobalExceptionHandler handler = new GlobalExceptionHandler(List.of(errorAlertNotifier));
+        HttpServletRequest request = request("POST", "/api/v1/external-ai/evaluate");
+
+        handler.handleGeneralException(new UserExceptionHandler(ErrorCode.EXTERNAL_AI_CALL_FAILED), request);
+
+        ArgumentCaptor<ErrorAlertContext> contextCaptor = ArgumentCaptor.forClass(ErrorAlertContext.class);
+        verify(errorAlertNotifier).notify(contextCaptor.capture());
+        assertThat(contextCaptor.getValue().errorCode()).isEqualTo("AI50201");
+        assertThat(contextCaptor.getValue().uri()).isEqualTo("/api/v1/external-ai/evaluate");
+    }
+
+    @Test
+    @DisplayName("handleNotFound()는 4xx 예외에서 Discord 알림을 보내지 않는다")
+    void handleNotFound_doesNotNotifyDiscordForClientErrors() {
+        GlobalExceptionHandler handler = new GlobalExceptionHandler(List.of(errorAlertNotifier));
+        HttpServletRequest request = request("GET", "/api/v1/folders");
+
+        handler.handleNotFound(new NoHandlerFoundException("GET", "/api/v1/folders", null), request);
+
+        verify(errorAlertNotifier, never()).notify(org.mockito.ArgumentMatchers.any());
+    }
+
+    private HttpServletRequest request(String method, String uri) {
+        MockHttpServletRequest request = new MockHttpServletRequest(method, uri);
+        request.setRemoteAddr("127.0.0.1");
+        return request;
+    }
+}

--- a/ssd-infra/build.gradle
+++ b/ssd-infra/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/ssd-infra/src/main/java/or/hyu/ssd/infra/alert/DiscordWebhookNotifier.java
+++ b/ssd-infra/src/main/java/or/hyu/ssd/infra/alert/DiscordWebhookNotifier.java
@@ -1,0 +1,102 @@
+package or.hyu.ssd.infra.alert;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import or.hyu.ssd.global.alert.ErrorAlertContext;
+import or.hyu.ssd.global.alert.ErrorAlertNotifier;
+import or.hyu.ssd.global.config.properties.DiscordProperties;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DiscordWebhookNotifier implements ErrorAlertNotifier {
+
+    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(5);
+    private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    private final ObjectMapper objectMapper;
+    private final DiscordProperties discordProperties;
+    private final Environment environment;
+
+    private final HttpClient httpClient = HttpClient.newBuilder()
+            .connectTimeout(REQUEST_TIMEOUT)
+            .build();
+
+    @Override
+    public void notify(ErrorAlertContext context) {
+        if (!discordProperties.hasWebhookUrl()) {
+            log.debug("Discord webhook URL is not configured. Skip sending.");
+            return;
+        }
+
+        try {
+            String payload = objectMapper.writeValueAsString(new DiscordWebhookPayload(buildMessage(context)));
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(discordProperties.getWebhookUrl()))
+                    .timeout(REQUEST_TIMEOUT)
+                    .header("Content-Type", "application/json")
+                    .POST(HttpRequest.BodyPublishers.ofString(payload, StandardCharsets.UTF_8))
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(
+                    request,
+                    HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8)
+            );
+
+            if (response.statusCode() < 200 || response.statusCode() >= 300) {
+                log.warn("Discord webhook failed. status={}, body={}", response.statusCode(), response.body());
+            }
+        } catch (Exception e) {
+            log.warn("Discord webhook failed.", e);
+        }
+    }
+
+    private String buildMessage(ErrorAlertContext context) {
+        return """
+                [SSD 서버 예외 알림]
+                - 시간: %s
+                - 환경: %s
+                - 코드: %s
+                - 상태: %d
+                - 메서드: %s
+                - 경로: %s
+                - IP: %s
+                - 예외: %s
+                - 메시지: %s
+                """.formatted(
+                LocalDateTime.now().format(TIME_FORMATTER),
+                resolveEnvironment(),
+                context.errorCode(),
+                context.status(),
+                context.method(),
+                context.uri(),
+                context.clientIp(),
+                context.exceptionClass(),
+                context.message()
+        );
+    }
+
+    private String resolveEnvironment() {
+        String[] activeProfiles = environment.getActiveProfiles();
+        if (activeProfiles.length == 0) {
+            return "default";
+        }
+        return String.join(",", Arrays.asList(activeProfiles));
+    }
+
+    private record DiscordWebhookPayload(String content) {
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue

- close #81


<br><br>

## 📝 Summary

- Sentry SDK를 연동해 전역 예외를 수집하도록 구성했습니다.
- 5xx 예외를 Discord webhook으로 전송하는 알림 파이프라인을 추가했습니다.
- 예외 핸들러 단위 테스트와 설정 placeholder를 함께 정리했습니다.


<br><br>

## 🙏 Details

- `ssd-api`에 `sentry-spring-boot-starter-jakarta`를 추가하고 `application.yml`에 `sentry.*`, `discord.webhook-url` placeholder를 등록했습니다.
- `ssd-core`의 `GlobalExceptionHandler`에서 모든 예외를 `Sentry.captureException()`으로 수집하도록 변경했습니다.
- Discord 알림은 운영 노이즈를 줄이기 위해 5xx 응답만 전송하도록 제한했습니다.
- 모듈 경계를 지키기 위해 `ssd-core`에 `ErrorAlertNotifier` 인터페이스와 `ErrorAlertContext`를 두고, `ssd-infra`에서 `DiscordWebhookNotifier`로 구현했습니다.
- Discord 알림 메시지에는 환경, 에러 코드, 상태 코드, 메서드, 경로, 클라이언트 IP, 예외 클래스, 메시지를 포함했습니다.
- `GlobalExceptionHandlerTest`로 5xx 예외 알림 전송 / 4xx 예외 미전송을 검증했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 출시 노트

* **새로운 기능**
  * 에러 추적 및 모니터링 시스템 통합
  * Discord 웹훅을 통한 서버 에러 알림 기능 추가

* **테스트**
  * 에러 알림 처리에 대한 테스트 케이스 추가

* **기타**
  * 에러 알림 인프라 지원을 위한 의존성 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->