### PR TITLE
[FIX] 스프링부트 4 센트리 초기화 호환성 수정

### DIFF
--- a/ssd-api/build.gradle
+++ b/ssd-api/build.gradle
@@ -16,7 +16,6 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.0'
-    implementation 'io.sentry:sentry-spring-boot-starter-jakarta:7.9.0'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 
     runtimeOnly 'org.postgresql:postgresql'

--- a/ssd-api/src/main/resources/application.yml
+++ b/ssd-api/src/main/resources/application.yml
@@ -95,8 +95,6 @@ discord:
 
 sentry:
   dsn: ${SENTRY_DSN:}
-  exception-resolver-order: -2147483647
-  max-request-body-size: always
   send-default-pii: true
   environment: ${SENTRY_ENVIRONMENT:${spring.application.name}}
 

--- a/ssd-core/src/main/java/or/hyu/ssd/global/api/GlobalExceptionHandler.java
+++ b/ssd-core/src/main/java/or/hyu/ssd/global/api/GlobalExceptionHandler.java
@@ -28,7 +28,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<ApiResponse<Void>> handleGeneralException(CustomException e, HttpServletRequest request) {
         ErrorCode errorCode = e.getErrorCode();
-        log.warn("Handled CustomException: {} - {}", errorCode.getCode(), errorCode.getMessage(), e);
+        log.warn("CustomException 처리 완료: {} - {}", errorCode.getCode(), errorCode.getMessage(), e);
         captureAndNotify(e, errorCode, request);
         ApiResponse<Void> response = ApiResponse.fail(errorCode);
 
@@ -38,7 +38,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(NoHandlerFoundException.class)
     public ResponseEntity<ApiResponse<Void>> handleNotFound(NoHandlerFoundException e, HttpServletRequest request) {
         ErrorCode errorCode = ErrorCode.REQUEST_API_NOT_FOUND;
-        log.warn("API not found: {} {}", e.getHttpMethod(), e.getRequestURL());
+        log.warn("존재하지 않는 API 요청: {} {}", e.getHttpMethod(), e.getRequestURL());
         captureAndNotify(e, errorCode, request);
         return ResponseEntity.status(errorCode.getStatus())
                 .body(ApiResponse.fail(errorCode));
@@ -47,7 +47,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
     public ResponseEntity<ApiResponse<Void>> handleMethodNotAllowed(HttpRequestMethodNotSupportedException e, HttpServletRequest request) {
         ErrorCode errorCode = ErrorCode.REQUEST_METHOD_NOT_ALLOWED;
-        log.warn("Method not allowed: {}", e.getMessage());
+        log.warn("허용되지 않은 HTTP 메서드 요청: {}", e.getMessage());
         captureAndNotify(e, errorCode, request);
         return ResponseEntity.status(errorCode.getStatus())
                 .body(ApiResponse.fail(errorCode));
@@ -56,7 +56,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Void>> handleUnhandledException(Exception e, HttpServletRequest request) {
         ErrorCode errorCode = ErrorCode.SERVER_EXCEPTION;
-        log.error("Unhandled exception", e);
+        log.error("처리되지 않은 예외가 발생했습니다", e);
         captureAndNotify(e, errorCode, request);
         return ResponseEntity.status(errorCode.getStatus())
                 .body(ApiResponse.fail(errorCode));
@@ -65,7 +65,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(ObjectOptimisticLockingFailureException.class)
     public ResponseEntity<ApiResponse<Void>> handleOptimisticLock(ObjectOptimisticLockingFailureException e, HttpServletRequest request) {
         ErrorCode errorCode = ErrorCode.CHECKLIST_CONFLICT;
-        log.warn("Optimistic locking failure: {}", e.getMessage());
+        log.warn("낙관적 락 충돌이 발생했습니다: {}", e.getMessage());
         captureAndNotify(e, errorCode, request);
         return ResponseEntity.status(errorCode.getStatus())
                 .body(ApiResponse.fail(errorCode));
@@ -74,7 +74,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<ApiResponse<Void>> handleNotReadable(HttpMessageNotReadableException e, HttpServletRequest request) {
         ErrorCode errorCode = ErrorCode.REQUEST_BODY_INVALID_JSON;
-        log.warn("JSON parse error: {}", e.getMessage());
+        log.warn("JSON 파싱 오류가 발생했습니다: {}", e.getMessage());
         captureAndNotify(e, errorCode, request);
         return ResponseEntity.status(errorCode.getStatus())
                 .body(ApiResponse.fail(errorCode));

--- a/ssd-core/src/main/java/or/hyu/ssd/global/config/SentryConfig.java
+++ b/ssd-core/src/main/java/or/hyu/ssd/global/config/SentryConfig.java
@@ -1,0 +1,42 @@
+package or.hyu.ssd.global.config;
+
+import io.sentry.Sentry;
+import io.sentry.SentryOptions;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import or.hyu.ssd.global.config.properties.SentryProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class SentryConfig {
+
+    private final SentryProperties sentryProperties;
+
+    @PostConstruct
+    void init() {
+        if (!sentryProperties.hasDsn()) {
+            log.info("Sentry DSN이 없어 Sentry 초기화를 건너뜁니다.");
+            return;
+        }
+
+        Sentry.init(options -> {
+            options.setDsn(sentryProperties.getDsn());
+            options.setEnvironment(sentryProperties.getEnvironment());
+            options.setSendDefaultPii(sentryProperties.isSendDefaultPii());
+            options.setMaxRequestBodySize(SentryOptions.RequestSize.ALWAYS);
+        });
+
+        log.info("Sentry SDK 초기화를 완료했습니다. environment={}", sentryProperties.getEnvironment());
+    }
+
+    @PreDestroy
+    void close() {
+        if (sentryProperties.hasDsn()) {
+            Sentry.close();
+        }
+    }
+}

--- a/ssd-core/src/main/java/or/hyu/ssd/global/config/properties/SentryProperties.java
+++ b/ssd-core/src/main/java/or/hyu/ssd/global/config/properties/SentryProperties.java
@@ -1,0 +1,20 @@
+package or.hyu.ssd.global.config.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "sentry")
+public class SentryProperties {
+    private String dsn;
+    private String environment;
+    private boolean sendDefaultPii = true;
+
+    public boolean hasDsn() {
+        return dsn != null && !dsn.isBlank();
+    }
+}

--- a/ssd-infra/src/main/java/or/hyu/ssd/infra/alert/DiscordWebhookNotifier.java
+++ b/ssd-infra/src/main/java/or/hyu/ssd/infra/alert/DiscordWebhookNotifier.java
@@ -38,7 +38,7 @@ public class DiscordWebhookNotifier implements ErrorAlertNotifier {
     @Override
     public void notify(ErrorAlertContext context) {
         if (!discordProperties.hasWebhookUrl()) {
-            log.debug("Discord webhook URL is not configured. Skip sending.");
+            log.debug("Discord webhook URL이 설정되지 않아 전송을 건너뜁니다.");
             return;
         }
 
@@ -57,10 +57,10 @@ public class DiscordWebhookNotifier implements ErrorAlertNotifier {
             );
 
             if (response.statusCode() < 200 || response.statusCode() >= 300) {
-                log.warn("Discord webhook failed. status={}, body={}", response.statusCode(), response.body());
+                log.warn("Discord webhook 전송에 실패했습니다. status={}, body={}", response.statusCode(), response.body());
             }
         } catch (Exception e) {
-            log.warn("Discord webhook failed.", e);
+            log.warn("Discord webhook 전송 중 예외가 발생했습니다.", e);
         }
     }
 


### PR DESCRIPTION
## 📣 Related Issue

- close #81

<br><br>

## 📝 Summary

- Spring Boot 4 환경에서 호환되지 않는 Sentry starter를 제거했습니다.
- Sentry SDK를 수동 초기화하는 설정으로 교체해 CD 실패를 해결했습니다.
- 에러 파이프라인의 한글 로그 메시지도 함께 정리했습니다.

<br><br>

## 🙏 Details

- `io.sentry:sentry-spring-boot-starter-jakarta`가 Spring Boot 4 런타임에서 `WebClientAutoConfiguration`을 찾지 못해 앱 기동이 실패하던 문제를 수정했습니다.
- starter 대신 `io.sentry:sentry` SDK만 유지하고, `SentryConfig`에서 DSN 존재 시 수동으로 `Sentry.init(...)` 하도록 변경했습니다.
- 기존 `sentry` 설정 키는 유지하되 starter 전용 옵션은 제거해 설정 의미를 명확히 했습니다.
- `GlobalExceptionHandler`, `DiscordWebhookNotifier` 영문 로그를 한글로 통일했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  - 오류 추적 시스템 구성 재정리 및 최적화
  - 의존성 및 설정 파일 정리

* **Localization**
  - 로그 메시지를 한국어로 변환하여 사용자 경험 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->