### PR TITLE
[FIX] 인증 예외를 401 상세 응답으로 통일

### DIFF
--- a/ssd-api/src/main/java/or/hyu/ssd/global/config/AuthenticationEntryPointImpl.java
+++ b/ssd-api/src/main/java/or/hyu/ssd/global/config/AuthenticationEntryPointImpl.java
@@ -1,0 +1,37 @@
+package or.hyu.ssd.global.config;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import or.hyu.ssd.global.api.ApiResponse;
+import or.hyu.ssd.global.api.ErrorCode;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class AuthenticationEntryPointImpl implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException
+    ) throws IOException, ServletException {
+        writeErrorResponse(response, ErrorCode.ACCESS_TOKEN_REQUIRED);
+    }
+
+    private void writeErrorResponse(HttpServletResponse response, ErrorCode errorCode) throws IOException {
+        response.setStatus(errorCode.getStatus().value());
+        response.setContentType("application/json;charset=UTF-8");
+
+        ApiResponse<Void> apiResponse = ApiResponse.fail(errorCode);
+        response.getWriter().write(String.format(
+                "{\"code\":\"%s\",\"msg\":\"%s\"}",
+                apiResponse.code(),
+                apiResponse.msg()
+        ));
+    }
+}

--- a/ssd-api/src/main/java/or/hyu/ssd/global/config/SecurityConfig.java
+++ b/ssd-api/src/main/java/or/hyu/ssd/global/config/SecurityConfig.java
@@ -29,6 +29,7 @@ public class SecurityConfig {
 
 
     private final JWTFilter jwtFilter;
+    private final AuthenticationEntryPointImpl authenticationEntryPoint;
 
     @Bean
     public BCryptPasswordEncoder bCryptPasswordEncoder(){
@@ -104,6 +105,9 @@ public class SecurityConfig {
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
         http.logout(AbstractHttpConfigurer::disable);
+
+        http.exceptionHandling(exception -> exception
+                .authenticationEntryPoint(authenticationEntryPoint));
 
         http.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
 

--- a/ssd-api/src/main/java/or/hyu/ssd/global/jwt/JWTFilter.java
+++ b/ssd-api/src/main/java/or/hyu/ssd/global/jwt/JWTFilter.java
@@ -2,6 +2,7 @@ package or.hyu.ssd.global.jwt;
 
 
 import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -11,6 +12,7 @@ import or.hyu.ssd.domain.member.entity.Role;
 import or.hyu.ssd.domain.member.service.CustomUserDetails;
 import or.hyu.ssd.domain.member.service.CustomUserDetailsService;
 import or.hyu.ssd.global.api.ErrorCode;
+import or.hyu.ssd.global.api.handler.UserExceptionHandler;
 import or.hyu.ssd.global.config.properties.JWTConfig;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -39,66 +41,52 @@ public class JWTFilter extends OncePerRequestFilter{
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 
-        String accessToken = null;
-
         String authorizationHeader = request.getHeader(jwtConfig.getHeader());
 
-        // Authorization 헤더가 없거나 Bearer 스킴이 없으면 다음 필터로 이동
-        if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
+        // Authorization 헤더가 없으면 Security EntryPoint에서 401을 반환합니다.
+        if (authorizationHeader == null) {
             filterChain.doFilter(request, response);
             return;
         }
+        if (!authorizationHeader.startsWith("Bearer ")) {
+            setErrorResponse(response, ErrorCode.ACCESS_INVALID_TYPE);
+            return;
+        }
         // Bearer 뒤의 토큰을 추출
-        accessToken = authorizationHeader.substring(7).trim();
+        String accessToken = authorizationHeader.substring(7).trim();
 
-
-        /**
-         * 토큰의 유효시간을 검증하고
-         * 토큰의 헤더가 access인지 확인해서 액세스토큰이 맞는지 검증한다
-         * */
         try {
-
             jwtUtil.isExpired(accessToken);
-
-
             String category = jwtUtil.getCategory(accessToken);
             if (!"access".equals(category)) {
                 setErrorResponse(response, ErrorCode.ACCESS_INVALID_TYPE);
                 return;
             }
+            Long id = jwtUtil.getId(accessToken);
+            String roleString = jwtUtil.getRole(accessToken);
+            Role.valueOf(roleString);
+            CustomUserDetails customUserDetails = customUserDetailsService.loadUserById(id);
 
+            Authentication authToken = new UsernamePasswordAuthenticationToken(
+                    customUserDetails,
+                    null,
+                    customUserDetails.getAuthorities()
+            );
+            SecurityContextHolder.getContext().setAuthentication(authToken);
+            filterChain.doFilter(request, response);
         } catch (ExpiredJwtException e) {
             setErrorResponse(response, ErrorCode.ACCESS_TOKEN_EXPIRED);
-            return;
-        }
-
-        //토큰에서 id와 role 획득
-        Long id = jwtUtil.getId(accessToken);
-        String roleString = jwtUtil.getRole(accessToken);
-
-        // String role을 Role enum으로 변환
-        Role role;
-        try {
-                role = Role.valueOf(roleString);
-            } catch (IllegalArgumentException e) {
-                setErrorResponse(response, ErrorCode.ROLE_INVALID_TYPE);
+        } catch (IllegalArgumentException e) {
+            setErrorResponse(response, ErrorCode.ROLE_INVALID_TYPE);
+        } catch (UserExceptionHandler e) {
+            if (e.getErrorCode() == ErrorCode.MEMBER_NOT_FOUND) {
+                setErrorResponse(response, ErrorCode.TOKEN_MEMBER_NOT_FOUND);
                 return;
             }
-
-
-        /**
-         * UserDetails에 회원 정보 객체 담아서 요청에 회원정보가 필요한 경우 가져다 쓴다
-         *
-         * 해당 객체의 생명주기는 한 요청이기 때문에 세션유지와는 차이가 존재한다
-         * */
-        CustomUserDetails customUserDetails = customUserDetailsService.loadUserById(id);
-
-        //스프링 시큐리티 인증 토큰 생성
-        Authentication authToken = new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
-        //세션에 사용자 등록
-        SecurityContextHolder.getContext().setAuthentication(authToken);
-
-        filterChain.doFilter(request, response);
+            throw e;
+        } catch (JwtException e) {
+            setErrorResponse(response, resolveJwtErrorCode(e));
+        }
     }
 
 
@@ -110,9 +98,17 @@ public class JWTFilter extends OncePerRequestFilter{
         response.setStatus(errorCode.getStatus().value());
         response.setContentType("application/json;charset=UTF-8");
         response.getWriter().write(String.format(
-                "{\"code\":%d, \"message\":\"%s\"}",
+                "{\"code\":\"%s\", \"msg\":\"%s\"}",
                 errorCode.getCode(), errorCode.getMessage()
         ));
+    }
+
+    private ErrorCode resolveJwtErrorCode(JwtException e) {
+        String simpleName = e.getClass().getSimpleName();
+        if ("SignatureException".equals(simpleName) || "MalformedJwtException".equals(simpleName)) {
+            return ErrorCode.INVALID_SIGNATURE;
+        }
+        return ErrorCode.INVALID_TOKEN;
     }
 
 }

--- a/ssd-api/src/test/java/or/hyu/ssd/global/config/AuthenticationEntryPointImplTest.java
+++ b/ssd-api/src/test/java/or/hyu/ssd/global/config/AuthenticationEntryPointImplTest.java
@@ -1,0 +1,34 @@
+package or.hyu.ssd.global.config;
+
+import jakarta.servlet.ServletException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import or.hyu.ssd.global.api.ErrorCode;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.InsufficientAuthenticationException;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AuthenticationEntryPointImplTest {
+
+    @Test
+    @DisplayName("인증되지 않은 요청은 401과 액세스 토큰 필요 메시지를 반환한다")
+    void commence_unauthenticatedRequest_returnsUnauthorized() throws ServletException, IOException {
+        AuthenticationEntryPointImpl entryPoint = new AuthenticationEntryPointImpl();
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        entryPoint.commence(
+                request,
+                response,
+                new InsufficientAuthenticationException("인증 필요")
+        );
+
+        assertThat(response.getStatus()).isEqualTo(ErrorCode.ACCESS_TOKEN_REQUIRED.getStatus().value());
+        assertThat(response.getContentAsString()).contains(ErrorCode.ACCESS_TOKEN_REQUIRED.getCode());
+        assertThat(response.getContentAsString()).contains(ErrorCode.ACCESS_TOKEN_REQUIRED.getMessage());
+    }
+}

--- a/ssd-api/src/test/java/or/hyu/ssd/global/jwt/JWTFilterTest.java
+++ b/ssd-api/src/test/java/or/hyu/ssd/global/jwt/JWTFilterTest.java
@@ -1,0 +1,95 @@
+package or.hyu.ssd.global.jwt;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.ServletException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import or.hyu.ssd.domain.member.service.CustomUserDetailsService;
+import or.hyu.ssd.global.api.ErrorCode;
+import or.hyu.ssd.global.api.handler.UserExceptionHandler;
+import or.hyu.ssd.global.config.properties.JWTConfig;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockFilterChain;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class JWTFilterTest {
+
+    @Mock
+    private JWTUtil jwtUtil;
+
+    @Mock
+    private JWTConfig jwtConfig;
+
+    @Mock
+    private CustomUserDetailsService customUserDetailsService;
+
+    @Test
+    @DisplayName("Bearer 스킴이 아닌 Authorization 헤더는 401과 상세 메시지를 반환한다")
+    void doFilterInternal_invalidAuthorizationHeader_returnsUnauthorized() throws ServletException, IOException {
+        JWTFilter jwtFilter = new JWTFilter(jwtUtil, jwtConfig, customUserDetailsService);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain filterChain = new MockFilterChain();
+
+        when(jwtConfig.getHeader()).thenReturn("Authorization");
+        request.addHeader("Authorization", "Token invalid");
+
+        jwtFilter.doFilterInternal(request, response, filterChain);
+
+        assertThat(response.getStatus()).isEqualTo(ErrorCode.ACCESS_INVALID_TYPE.getStatus().value());
+        assertThat(response.getContentAsString()).contains(ErrorCode.ACCESS_INVALID_TYPE.getCode());
+        assertThat(response.getContentAsString()).contains(ErrorCode.ACCESS_INVALID_TYPE.getMessage());
+    }
+
+    @Test
+    @DisplayName("만료된 액세스 토큰은 401과 만료 메시지를 반환한다")
+    void doFilterInternal_expiredAccessToken_returnsUnauthorized() throws ServletException, IOException {
+        JWTFilter jwtFilter = new JWTFilter(jwtUtil, jwtConfig, customUserDetailsService);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain filterChain = new MockFilterChain();
+
+        when(jwtConfig.getHeader()).thenReturn("Authorization");
+        request.addHeader("Authorization", "Bearer expired-token");
+        when(jwtUtil.isExpired("expired-token")).thenThrow(new ExpiredJwtException(null, null, "expired"));
+
+        jwtFilter.doFilterInternal(request, response, filterChain);
+
+        assertThat(response.getStatus()).isEqualTo(ErrorCode.ACCESS_TOKEN_EXPIRED.getStatus().value());
+        assertThat(response.getContentAsString()).contains(ErrorCode.ACCESS_TOKEN_EXPIRED.getCode());
+        assertThat(response.getContentAsString()).contains(ErrorCode.ACCESS_TOKEN_EXPIRED.getMessage());
+    }
+
+    @Test
+    @DisplayName("토큰의 회원이 존재하지 않으면 401과 상세 메시지를 반환한다")
+    void doFilterInternal_tokenMemberNotFound_returnsUnauthorized() throws ServletException, IOException {
+        JWTFilter jwtFilter = new JWTFilter(jwtUtil, jwtConfig, customUserDetailsService);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain filterChain = new MockFilterChain();
+
+        when(jwtConfig.getHeader()).thenReturn("Authorization");
+        request.addHeader("Authorization", "Bearer valid-token");
+        when(jwtUtil.isExpired("valid-token")).thenReturn(false);
+        when(jwtUtil.getCategory("valid-token")).thenReturn("access");
+        when(jwtUtil.getId("valid-token")).thenReturn(1L);
+        when(jwtUtil.getRole("valid-token")).thenReturn("ROLE_AUTHOR");
+        when(customUserDetailsService.loadUserById(1L))
+                .thenThrow(new UserExceptionHandler(ErrorCode.MEMBER_NOT_FOUND));
+
+        jwtFilter.doFilterInternal(request, response, filterChain);
+
+        assertThat(response.getStatus()).isEqualTo(ErrorCode.TOKEN_MEMBER_NOT_FOUND.getStatus().value());
+        assertThat(response.getContentAsString()).contains(ErrorCode.TOKEN_MEMBER_NOT_FOUND.getCode());
+        assertThat(response.getContentAsString()).contains(ErrorCode.TOKEN_MEMBER_NOT_FOUND.getMessage());
+    }
+}

--- a/ssd-core/src/main/java/or/hyu/ssd/global/api/ErrorCode.java
+++ b/ssd-core/src/main/java/or/hyu/ssd/global/api/ErrorCode.java
@@ -58,12 +58,14 @@ public enum ErrorCode {
     TOKEN_SECRET_IS_NULL(HttpStatus.INTERNAL_SERVER_ERROR, "TOKEN50001","JWT SECRET KEY가 주입되지 않았습니다"),
     ACCESS_INVALID_TYPE(HttpStatus.UNAUTHORIZED,"TOKEN40301" ,"ACCESS 토큰이 헤더가 올바르지 않습니다" ),
     ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED,"TOKEN40302" ,"ACCESS 토큰이 만료되었습니다" ),
-    ROLE_INVALID_TYPE(HttpStatus.BAD_REQUEST,"TOKEN40001","존재하지 않는 인가 권한입니다"),
+    ROLE_INVALID_TYPE(HttpStatus.UNAUTHORIZED,"TOKEN40308","토큰의 인가 권한 정보가 올바르지 않습니다"),
     COOKIE_NULL(HttpStatus.UNAUTHORIZED,"TOKEN40303" ,"쿠키가 비어있습니다" ),
     REFRESH_TOKEN_NULL(HttpStatus.UNAUTHORIZED,"TOKEN40304" ,"리프레시 토큰이 비어있습니다" ),
     REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED,"TOKEN40305" ,"리프레시 토큰이 만료되었습니다"),
     INVALID_SIGNATURE(HttpStatus.UNAUTHORIZED,"TOKEN40306" ,"JWT 시그니처가 위조되었습니다" ),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED,"TOKEN40307" ,"유효하지 않은 토큰입니다"),
+    ACCESS_TOKEN_REQUIRED(HttpStatus.UNAUTHORIZED,"TOKEN40309" ,"액세스 토큰이 필요합니다"),
+    TOKEN_MEMBER_NOT_FOUND(HttpStatus.UNAUTHORIZED,"TOKEN40310" ,"토큰에 해당하는 회원을 찾을 수 없습니다"),
 
     // 요청 바디/JSON 파싱 예외
     REQUEST_BODY_INVALID_JSON(HttpStatus.BAD_REQUEST, "REQ40001", "요청 본문 JSON 파싱에 실패했습니다. 문자열의 개행은 \\n 로 이스케이프해 주세요"),


### PR DESCRIPTION
## 📣 Related Issue

- close #86


<br><br>

## 📝 Summary

- 인증 관련 예외를 401 응답으로 통일했습니다.
- 액세스 토큰 누락/형식 오류/만료/회원 미존재에 대한 상세 메시지를 반환하도록 수정했습니다.
- JWT 필터 및 인증 진입점 테스트를 추가했습니다.


<br><br>

## 🙏 Details

- Spring Security 기본 인증 실패 응답 대신 `AuthenticationEntryPointImpl`를 추가해 인증 정보가 없는 요청을 `401 + ACCESS_TOKEN_REQUIRED`로 반환하도록 변경했습니다.
- `JWTFilter`에서 Bearer 스킴 오류, 액세스 토큰 만료, 토큰 회원 미존재, 잘못된 서명/유효하지 않은 토큰을 각각 구체적인 `ErrorCode`로 매핑했습니다.
- 필터 응답 바디 형식을 `ApiResponse` 규약과 맞춘 `code/msg` 구조로 정리하고, 기존 포맷팅 오류도 함께 제거했습니다.
- `AuthenticationEntryPointImplTest`, `JWTFilterTest`를 추가해 401 상태코드와 상세 메시지를 검증했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 인증 실패 시 구체적인 오류 메시지 및 코드 제공
* JWT 토큰 검증 강화로 만료, 서명 오류, 권한 문제 등을 구별하여 처리

## 버그 수정
* 유효하지 않은 인증 헤더에 대한 명확한 오류 응답 개선
* 토큰의 회원 정보 부재 시 적절한 오류 처리

## 테스트
* 인증 및 JWT 필터 동작 검증을 위한 단위 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->