### PR TITLE
[CHORE] 에러핸들링 보강

### DIFF
--- a/ssd-api/src/main/java/or/hyu/ssd/domain/document/controller/DocumentCommentController.java
+++ b/ssd-api/src/main/java/or/hyu/ssd/domain/document/controller/DocumentCommentController.java
@@ -13,6 +13,7 @@ import or.hyu.ssd.domain.member.service.CustomUserDetails;
 import or.hyu.ssd.global.api.ApiResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -23,10 +24,12 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.DeleteMapping;
 
 import java.util.List;
+import jakarta.validation.constraints.Positive;
 
 @RestController
 @RequestMapping("/api")
 @RequiredArgsConstructor
+@Validated
 @Tag(name = "주석 API", description = "문단 주석 생성/조회")
 public class DocumentCommentController {
 
@@ -59,7 +62,7 @@ public class DocumentCommentController {
                     """
     )
     public ResponseEntity<ApiResponse<DocumentCommentResponse>> create(
-            @PathVariable Long documentId,
+            @PathVariable @Positive(message = "문서 ID는 1 이상이어야 합니다") Long documentId,
             @Valid @RequestBody DocumentCommentRequest request,
             @AuthenticationPrincipal CustomUserDetails user
     ) {
@@ -93,7 +96,7 @@ public class DocumentCommentController {
                     """
     )
     public ResponseEntity<ApiResponse<DocumentCommentResponse>> update(
-            @PathVariable Long id,
+            @PathVariable @Positive(message = "주석 ID는 1 이상이어야 합니다") Long id,
             @Valid @RequestBody DocumentCommentUpdateRequest request,
             @AuthenticationPrincipal CustomUserDetails user
     ) {
@@ -125,7 +128,7 @@ public class DocumentCommentController {
                     """
     )
     public ResponseEntity<ApiResponse<String>> delete(
-            @PathVariable Long id,
+            @PathVariable @Positive(message = "주석 ID는 1 이상이어야 합니다") Long id,
             @AuthenticationPrincipal CustomUserDetails user
     ) {
         documentCommentService.delete(id, user);
@@ -155,7 +158,7 @@ public class DocumentCommentController {
                     """
     )
     public ResponseEntity<ApiResponse<List<DocumentCommentItemResponse>>> list(
-            @PathVariable Long documentId,
+            @PathVariable @Positive(message = "문서 ID는 1 이상이어야 합니다") Long documentId,
             @AuthenticationPrincipal CustomUserDetails user
     ) {
         List<DocumentCommentItemResponse> items = documentCommentService.list(documentId, user);

--- a/ssd-api/src/main/java/or/hyu/ssd/domain/document/controller/DocumentController.java
+++ b/ssd-api/src/main/java/or/hyu/ssd/domain/document/controller/DocumentController.java
@@ -14,8 +14,11 @@ import or.hyu.ssd.domain.member.service.CustomUserDetails;
 import or.hyu.ssd.global.api.ApiResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
 import or.hyu.ssd.domain.document.controller.dto.GetDocumentResponse;
 import or.hyu.ssd.domain.document.controller.dto.DocumentListItemResponse;
 import or.hyu.ssd.domain.document.service.support.DocumentSort;
@@ -25,6 +28,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/api")
 @RequiredArgsConstructor
+@Validated
 @Tag(
         name = "문서 API",
         description = "문서 CRUD와 즐겨찾기 토글 엔드포인트"
@@ -102,8 +106,8 @@ public class DocumentController {
     )
     public ResponseEntity<ApiResponse<UpdateDocumentResponse>> updateDocument(
             @Parameter(description = "수정할 문서 ID", example = "42")
-            @PathVariable("id") Long id,
-            @RequestBody UpdateDocumentRequest request,
+            @PathVariable("id") @Positive(message = "문서 ID는 1 이상이어야 합니다") Long id,
+            @Valid @RequestBody UpdateDocumentRequest request,
             @AuthenticationPrincipal CustomUserDetails user
     ) {
         UpdateDocumentResponse dto = documentService.updateDocument(id, user, request);
@@ -136,7 +140,7 @@ public class DocumentController {
     )
     public ResponseEntity<ApiResponse<String>> deleteDocument(
             @Parameter(description = "삭제할 문서 ID", example = "42")
-            @PathVariable("id") Long id,
+            @PathVariable("id") @Positive(message = "문서 ID는 1 이상이어야 합니다") Long id,
             @AuthenticationPrincipal CustomUserDetails user
     ) {
         documentService.deleteDocument(id, user);
@@ -171,7 +175,7 @@ public class DocumentController {
     )
     public ResponseEntity<ApiResponse<GetDocumentResponse>> getDocument(
             @Parameter(description = "조회할 문서 ID", example = "42")
-            @PathVariable("id") Long id,
+            @PathVariable("id") @Positive(message = "문서 ID는 1 이상이어야 합니다") Long id,
             @AuthenticationPrincipal CustomUserDetails user
     ) {
         GetDocumentResponse dto = documentService.getDocument(id, user);
@@ -217,7 +221,7 @@ public class DocumentController {
             @Parameter(description = "정렬 옵션", schema = @Schema(allowableValues = {"LATEST","OLDEST","NAME","MODIFIED"}))
             @RequestParam(name = "sort", defaultValue = "LATEST") DocumentSort sort,
             @Parameter(description = "폴더 ID (없으면 전체, 0이면 루트)")
-            @RequestParam(name = "folderId", required = false) Long folderId
+            @RequestParam(name = "folderId", required = false) @PositiveOrZero(message = "folderId는 0 이상이어야 합니다") Long folderId
     ) {
         List<DocumentListItemResponse> list = documentService.listDocuments(user, sort, folderId);
         return ResponseEntity.ok(ApiResponse.ok(list, "문서 목록이 조회되었습니다"));
@@ -251,7 +255,7 @@ public class DocumentController {
     )
     public ResponseEntity<ApiResponse<DocumentBookmarkResponse>> toggleBookmark(
             @Parameter(description = "즐겨찾기 토글 대상 문서 ID", example = "42")
-            @PathVariable("id") Long id,
+            @PathVariable("id") @Positive(message = "문서 ID는 1 이상이어야 합니다") Long id,
             @AuthenticationPrincipal CustomUserDetails user
     ) {
         DocumentBookmarkResponse dto = documentService.toggleBookmark(id, user);

--- a/ssd-api/src/main/java/or/hyu/ssd/domain/document/controller/FolderController.java
+++ b/ssd-api/src/main/java/or/hyu/ssd/domain/document/controller/FolderController.java
@@ -16,11 +16,15 @@ import or.hyu.ssd.domain.member.service.CustomUserDetails;
 import or.hyu.ssd.global.api.ApiResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
 
 @RestController
 @RequestMapping("/api")
 @RequiredArgsConstructor
+@Validated
 @Tag(
         name = "폴더 API",
         description = "폴더 CRUD 엔드포인트"
@@ -81,8 +85,8 @@ public class FolderController {
     )
     public ResponseEntity<ApiResponse<UpdateFolderResponse>> updateFolder(
             @Parameter(description = "수정할 폴더 ID", example = "42")
-            @PathVariable("id") Long id,
-            @RequestBody UpdateFolderRequest request,
+            @PathVariable("id") @Positive(message = "폴더 ID는 1 이상이어야 합니다") Long id,
+            @Valid @RequestBody UpdateFolderRequest request,
             @AuthenticationPrincipal CustomUserDetails user
     ) {
         UpdateFolderResponse dto = folderService.update(id, user, request);
@@ -109,7 +113,7 @@ public class FolderController {
     )
     public ResponseEntity<ApiResponse<String>> deleteFolder(
             @Parameter(description = "삭제할 폴더 ID", example = "42")
-            @PathVariable("id") Long id,
+            @PathVariable("id") @Positive(message = "폴더 ID는 1 이상이어야 합니다") Long id,
             @AuthenticationPrincipal CustomUserDetails user
     ) {
         folderService.delete(id, user);
@@ -141,7 +145,7 @@ public class FolderController {
     public ResponseEntity<ApiResponse<FolderContentResponse>> listFolders(
             @AuthenticationPrincipal CustomUserDetails user,
             @Parameter(description = "부모 폴더 ID (없으면 루트)", schema = @Schema(type = "integer", example = "0"))
-            @RequestParam(name = "parentId", required = false) Long parentId
+            @RequestParam(name = "parentId", required = false) @PositiveOrZero(message = "parentId는 0 이상이어야 합니다") Long parentId
     ) {
         FolderContentResponse data = folderService.listContent(user, parentId);
         return ResponseEntity.ok(ApiResponse.ok(data, "폴더 내용이 조회되었습니다"));

--- a/ssd-api/src/main/java/or/hyu/ssd/global/config/AccessDeniedHandlerImpl.java
+++ b/ssd-api/src/main/java/or/hyu/ssd/global/config/AccessDeniedHandlerImpl.java
@@ -1,0 +1,37 @@
+package or.hyu.ssd.global.config;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import or.hyu.ssd.global.api.ApiResponse;
+import or.hyu.ssd.global.api.ErrorCode;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class AccessDeniedHandlerImpl implements AccessDeniedHandler {
+
+    @Override
+    public void handle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AccessDeniedException accessDeniedException
+    ) throws IOException, ServletException {
+        writeErrorResponse(response, ErrorCode.REQUEST_ACCESS_DENIED);
+    }
+
+    private void writeErrorResponse(HttpServletResponse response, ErrorCode errorCode) throws IOException {
+        response.setStatus(errorCode.getStatus().value());
+        response.setContentType("application/json;charset=UTF-8");
+
+        ApiResponse<Void> apiResponse = ApiResponse.fail(errorCode);
+        response.getWriter().write(String.format(
+                "{\"code\":\"%s\",\"msg\":\"%s\"}",
+                apiResponse.code(),
+                apiResponse.msg()
+        ));
+    }
+}

--- a/ssd-api/src/main/java/or/hyu/ssd/global/config/SecurityConfig.java
+++ b/ssd-api/src/main/java/or/hyu/ssd/global/config/SecurityConfig.java
@@ -30,6 +30,7 @@ public class SecurityConfig {
 
     private final JWTFilter jwtFilter;
     private final AuthenticationEntryPointImpl authenticationEntryPoint;
+    private final AccessDeniedHandlerImpl accessDeniedHandler;
 
     @Bean
     public BCryptPasswordEncoder bCryptPasswordEncoder(){
@@ -107,7 +108,8 @@ public class SecurityConfig {
         http.logout(AbstractHttpConfigurer::disable);
 
         http.exceptionHandling(exception -> exception
-                .authenticationEntryPoint(authenticationEntryPoint));
+                .authenticationEntryPoint(authenticationEntryPoint)
+                .accessDeniedHandler(accessDeniedHandler));
 
         http.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
 

--- a/ssd-api/src/test/java/or/hyu/ssd/global/config/AccessDeniedHandlerImplTest.java
+++ b/ssd-api/src/test/java/or/hyu/ssd/global/config/AccessDeniedHandlerImplTest.java
@@ -1,0 +1,29 @@
+package or.hyu.ssd.global.config;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import or.hyu.ssd.global.api.ErrorCode;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AccessDeniedHandlerImplTest {
+
+    @Test
+    @DisplayName("인가되지 않은 요청은 403과 권한 없음 메시지를 반환한다")
+    void handle_accessDenied_returnsForbidden() throws IOException, jakarta.servlet.ServletException {
+        AccessDeniedHandlerImpl handler = new AccessDeniedHandlerImpl();
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        handler.handle(request, response, new AccessDeniedException("forbidden"));
+
+        assertThat(response.getStatus()).isEqualTo(ErrorCode.REQUEST_ACCESS_DENIED.getStatus().value());
+        assertThat(response.getContentAsString()).contains(ErrorCode.REQUEST_ACCESS_DENIED.getCode());
+        assertThat(response.getContentAsString()).contains(ErrorCode.REQUEST_ACCESS_DENIED.getMessage());
+    }
+}

--- a/ssd-core/src/main/java/or/hyu/ssd/global/api/ApiResponse.java
+++ b/ssd-core/src/main/java/or/hyu/ssd/global/api/ApiResponse.java
@@ -18,4 +18,8 @@ public record ApiResponse<T>(String code, String msg, T data) {
     public static <T> ApiResponse<T> fail(ErrorCode errorCode) {
         return new ApiResponse<T>(errorCode.getCode(), errorCode.getMessage(), null);
     }
+
+    public static <T> ApiResponse<T> fail(ErrorCode errorCode, String msg) {
+        return new ApiResponse<T>(errorCode.getCode(), msg, null);
+    }
 }

--- a/ssd-core/src/main/java/or/hyu/ssd/global/api/ErrorCode.java
+++ b/ssd-core/src/main/java/or/hyu/ssd/global/api/ErrorCode.java
@@ -52,6 +52,12 @@ public enum ErrorCode {
     // 요청/라우팅 예외
     REQUEST_API_NOT_FOUND(HttpStatus.NOT_FOUND, "REQ40401", "요청하신 API를 찾지 못했습니다"),
     REQUEST_METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "REQ40501", "지원하지 않는 HTTP 메서드입니다"),
+    REQUEST_BODY_INVALID_VALUE(HttpStatus.BAD_REQUEST, "REQ40002", "요청 값 검증에 실패했습니다"),
+    REQUEST_PARAMETER_INVALID(HttpStatus.BAD_REQUEST, "REQ40003", "요청 파라미터 형식이 올바르지 않습니다"),
+    REQUEST_PARAMETER_MISSING(HttpStatus.BAD_REQUEST, "REQ40004", "필수 요청 파라미터가 누락되었습니다"),
+    REQUEST_HEADER_MISSING(HttpStatus.BAD_REQUEST, "REQ40005", "필수 요청 헤더가 누락되었습니다"),
+    REQUEST_MEDIA_TYPE_NOT_SUPPORTED(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "REQ41501", "지원하지 않는 Content-Type입니다"),
+    REQUEST_ACCESS_DENIED(HttpStatus.FORBIDDEN, "REQ40301", "해당 요청을 수행할 권한이 없습니다"),
 
 
     // 토큰 예외

--- a/ssd-core/src/main/java/or/hyu/ssd/global/api/GlobalExceptionHandler.java
+++ b/ssd-core/src/main/java/or/hyu/ssd/global/api/GlobalExceptionHandler.java
@@ -41,7 +41,7 @@ public class GlobalExceptionHandler {
         ErrorCode errorCode = e.getErrorCode();
         log.warn("CustomException 처리 완료: {} - {}", errorCode.getCode(), errorCode.getMessage(), e);
         captureAndNotify(e, errorCode, request);
-        ApiResponse<Void> response = ApiResponse.fail(errorCode);
+        ApiResponse<Void> response = ApiResponse.fail(errorCode, e.getDetailMessage());
 
         return ResponseEntity.status(errorCode.getStatus()).body(response);
     }

--- a/ssd-core/src/main/java/or/hyu/ssd/global/api/GlobalExceptionHandler.java
+++ b/ssd-core/src/main/java/or/hyu/ssd/global/api/GlobalExceptionHandler.java
@@ -2,6 +2,8 @@ package or.hyu.ssd.global.api;
 
 
 import io.sentry.Sentry;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -10,13 +12,22 @@ import or.hyu.ssd.global.alert.ErrorAlertNotifier;
 import or.hyu.ssd.global.api.handler.CustomException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.validation.BindException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestHeaderException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
 import java.util.List;
+import java.util.Optional;
 
 @RestControllerAdvice
 @Slf4j
@@ -53,6 +64,94 @@ public class GlobalExceptionHandler {
                 .body(ApiResponse.fail(errorCode));
     }
 
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMethodArgumentNotValid(MethodArgumentNotValidException e, HttpServletRequest request) {
+        ErrorCode errorCode = ErrorCode.REQUEST_BODY_INVALID_VALUE;
+        String message = resolveBindingMessage(e.getBindingResult().getFieldErrors())
+                .orElse(errorCode.getMessage());
+        log.warn("요청 본문 검증에 실패했습니다: {}", message);
+        captureAndNotify(e, errorCode, request);
+        return ResponseEntity.status(errorCode.getStatus())
+                .body(ApiResponse.fail(errorCode, message));
+    }
+
+    @ExceptionHandler(BindException.class)
+    public ResponseEntity<ApiResponse<Void>> handleBindException(BindException e, HttpServletRequest request) {
+        ErrorCode errorCode = ErrorCode.REQUEST_BODY_INVALID_VALUE;
+        String message = resolveBindingMessage(e.getBindingResult().getFieldErrors())
+                .orElse(errorCode.getMessage());
+        log.warn("요청 바인딩 검증에 실패했습니다: {}", message);
+        captureAndNotify(e, errorCode, request);
+        return ResponseEntity.status(errorCode.getStatus())
+                .body(ApiResponse.fail(errorCode, message));
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ApiResponse<Void>> handleConstraintViolation(ConstraintViolationException e, HttpServletRequest request) {
+        ErrorCode errorCode = ErrorCode.REQUEST_BODY_INVALID_VALUE;
+        String message = e.getConstraintViolations().stream()
+                .findFirst()
+                .map(ConstraintViolation::getMessage)
+                .filter(msg -> msg != null && !msg.isBlank())
+                .orElse(errorCode.getMessage());
+        log.warn("요청 제약 조건 검증에 실패했습니다: {}", message);
+        captureAndNotify(e, errorCode, request);
+        return ResponseEntity.status(errorCode.getStatus())
+                .body(ApiResponse.fail(errorCode, message));
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ApiResponse<Void>> handleTypeMismatch(MethodArgumentTypeMismatchException e, HttpServletRequest request) {
+        ErrorCode errorCode = ErrorCode.REQUEST_PARAMETER_INVALID;
+        String message = String.format("'%s' 파라미터 형식이 올바르지 않습니다", e.getName());
+        log.warn("요청 파라미터 타입이 올바르지 않습니다: {}", e.getMessage());
+        captureAndNotify(e, errorCode, request);
+        return ResponseEntity.status(errorCode.getStatus())
+                .body(ApiResponse.fail(errorCode, message));
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMissingParameter(MissingServletRequestParameterException e, HttpServletRequest request) {
+        ErrorCode errorCode = ErrorCode.REQUEST_PARAMETER_MISSING;
+        String message = String.format("'%s' 요청 파라미터가 누락되었습니다", e.getParameterName());
+        log.warn("필수 요청 파라미터가 누락되었습니다: {}", e.getMessage());
+        captureAndNotify(e, errorCode, request);
+        return ResponseEntity.status(errorCode.getStatus())
+                .body(ApiResponse.fail(errorCode, message));
+    }
+
+    @ExceptionHandler(MissingRequestHeaderException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMissingHeader(MissingRequestHeaderException e, HttpServletRequest request) {
+        ErrorCode errorCode = ErrorCode.REQUEST_HEADER_MISSING;
+        String message = String.format("'%s' 요청 헤더가 누락되었습니다", e.getHeaderName());
+        log.warn("필수 요청 헤더가 누락되었습니다: {}", e.getMessage());
+        captureAndNotify(e, errorCode, request);
+        return ResponseEntity.status(errorCode.getStatus())
+                .body(ApiResponse.fail(errorCode, message));
+    }
+
+    @ExceptionHandler(HttpMediaTypeNotSupportedException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMediaTypeNotSupported(HttpMediaTypeNotSupportedException e, HttpServletRequest request) {
+        ErrorCode errorCode = ErrorCode.REQUEST_MEDIA_TYPE_NOT_SUPPORTED;
+        String contentType = Optional.ofNullable(e.getContentType())
+                .map(Object::toString)
+                .orElse("알 수 없음");
+        String message = String.format("지원하지 않는 Content-Type입니다: %s", contentType);
+        log.warn("지원하지 않는 Content-Type 요청입니다: {}", e.getMessage());
+        captureAndNotify(e, errorCode, request);
+        return ResponseEntity.status(errorCode.getStatus())
+                .body(ApiResponse.fail(errorCode, message));
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ApiResponse<Void>> handleAccessDenied(AccessDeniedException e, HttpServletRequest request) {
+        ErrorCode errorCode = ErrorCode.REQUEST_ACCESS_DENIED;
+        log.warn("인가되지 않은 요청입니다: {}", e.getMessage());
+        captureAndNotify(e, errorCode, request);
+        return ResponseEntity.status(errorCode.getStatus())
+                .body(ApiResponse.fail(errorCode));
+    }
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Void>> handleUnhandledException(Exception e, HttpServletRequest request) {
         ErrorCode errorCode = ErrorCode.SERVER_EXCEPTION;
@@ -74,10 +173,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<ApiResponse<Void>> handleNotReadable(HttpMessageNotReadableException e, HttpServletRequest request) {
         ErrorCode errorCode = ErrorCode.REQUEST_BODY_INVALID_JSON;
+        String message = resolveJsonParseMessage(e);
         log.warn("JSON 파싱 오류가 발생했습니다: {}", e.getMessage());
         captureAndNotify(e, errorCode, request);
         return ResponseEntity.status(errorCode.getStatus())
-                .body(ApiResponse.fail(errorCode));
+                .body(ApiResponse.fail(errorCode, message));
     }
 
     private void captureAndNotify(Throwable throwable, ErrorCode errorCode, HttpServletRequest request) {
@@ -99,6 +199,37 @@ public class GlobalExceptionHandler {
 
     private boolean isServerError(ErrorCode errorCode) {
         return errorCode.getStatus().is5xxServerError();
+    }
+
+    private Optional<String> resolveBindingMessage(List<FieldError> fieldErrors) {
+        return fieldErrors.stream()
+                .findFirst()
+                .map(fieldError -> {
+                    String defaultMessage = fieldError.getDefaultMessage();
+                    if (defaultMessage != null && !defaultMessage.isBlank()) {
+                        return defaultMessage;
+                    }
+                    return String.format("'%s' 값이 올바르지 않습니다", fieldError.getField());
+                });
+    }
+
+    private String resolveJsonParseMessage(HttpMessageNotReadableException e) {
+        String rawMessage = Optional.ofNullable(e.getMostSpecificCause())
+                .map(Throwable::getMessage)
+                .orElse(e.getMessage());
+        if (rawMessage == null || rawMessage.isBlank()) {
+            return ErrorCode.REQUEST_BODY_INVALID_JSON.getMessage();
+        }
+        if (rawMessage.contains("Trailing token")) {
+            return "요청 본문에는 JSON 객체 하나만 포함되어야 합니다";
+        }
+        if (rawMessage.contains("Required request body is missing")) {
+            return "요청 본문이 비어 있습니다";
+        }
+        if (rawMessage.contains("Cannot deserialize value of type")) {
+            return "요청 본문 필드 형식이 올바르지 않습니다";
+        }
+        return ErrorCode.REQUEST_BODY_INVALID_JSON.getMessage();
     }
 
     private String resolveClientIp(HttpServletRequest request) {

--- a/ssd-core/src/main/java/or/hyu/ssd/global/api/handler/CustomException.java
+++ b/ssd-core/src/main/java/or/hyu/ssd/global/api/handler/CustomException.java
@@ -6,10 +6,16 @@ import or.hyu.ssd.global.api.ErrorCode;
 @Getter
 public abstract class CustomException extends RuntimeException {
     private final ErrorCode errorCode;
+    private final String detailMessage;
 
     protected CustomException(ErrorCode errorCode) {
-        super(errorCode.getMessage());
+        this(errorCode, errorCode.getMessage());
+    }
+
+    protected CustomException(ErrorCode errorCode, String detailMessage) {
+        super(detailMessage);
         this.errorCode = errorCode;
+        this.detailMessage = detailMessage;
     }
 }
 

--- a/ssd-core/src/main/java/or/hyu/ssd/global/api/handler/UserExceptionHandler.java
+++ b/ssd-core/src/main/java/or/hyu/ssd/global/api/handler/UserExceptionHandler.java
@@ -6,4 +6,8 @@ public class UserExceptionHandler extends CustomException {
     public UserExceptionHandler(ErrorCode errorCode) {
         super(errorCode);
     }
+
+    public UserExceptionHandler(ErrorCode errorCode, String detailMessage) {
+        super(errorCode, detailMessage);
+    }
 }

--- a/ssd-core/src/test/java/or/hyu/ssd/global/api/GlobalExceptionHandlerTest.java
+++ b/ssd-core/src/test/java/or/hyu/ssd/global/api/GlobalExceptionHandlerTest.java
@@ -7,12 +7,20 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import or.hyu.ssd.global.alert.ErrorAlertContext;
 import or.hyu.ssd.global.alert.ErrorAlertNotifier;
 import or.hyu.ssd.global.api.handler.UserExceptionHandler;
+import org.springframework.mock.http.MockHttpInputMessage;
 import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.FieldError;
 import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
+import java.lang.reflect.Method;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -50,9 +58,71 @@ class GlobalExceptionHandlerTest {
         verify(errorAlertNotifier, never()).notify(org.mockito.ArgumentMatchers.any());
     }
 
+    @Test
+    @DisplayName("handleMethodArgumentNotValid()는 첫 번째 검증 메시지를 반환한다")
+    void handleMethodArgumentNotValid_returnsFieldValidationMessage() throws NoSuchMethodException {
+        GlobalExceptionHandler handler = new GlobalExceptionHandler(List.of(errorAlertNotifier));
+        HttpServletRequest request = request("POST", "/api/v1/folders");
+        BeanPropertyBindingResult bindingResult = new BeanPropertyBindingResult(new Object(), "request");
+        bindingResult.addError(new FieldError("request", "name", "폴더명은 필수입니다"));
+        Method method = TestController.class.getDeclaredMethod("create", String.class);
+        MethodParameter methodParameter = new MethodParameter(method, 0);
+        MethodArgumentNotValidException exception = new MethodArgumentNotValidException(methodParameter, bindingResult);
+
+        var response = handler.handleMethodArgumentNotValid(exception, request);
+
+        assertThat(response.getStatusCode()).isEqualTo(ErrorCode.REQUEST_BODY_INVALID_VALUE.getStatus());
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().msg()).isEqualTo("폴더명은 필수입니다");
+        verify(errorAlertNotifier, never()).notify(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    @DisplayName("handleTypeMismatch()는 파라미터 이름을 포함한 메시지를 반환한다")
+    void handleTypeMismatch_returnsReadableMessage() {
+        GlobalExceptionHandler handler = new GlobalExceptionHandler(List.of(errorAlertNotifier));
+        HttpServletRequest request = request("GET", "/api/v1/documents");
+        MethodArgumentTypeMismatchException exception = new MethodArgumentTypeMismatchException(
+                "INVALID",
+                Long.class,
+                "folderId",
+                null,
+                new IllegalArgumentException("bad request")
+        );
+
+        var response = handler.handleTypeMismatch(exception, request);
+
+        assertThat(response.getStatusCode()).isEqualTo(ErrorCode.REQUEST_PARAMETER_INVALID.getStatus());
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().msg()).isEqualTo("'folderId' 파라미터 형식이 올바르지 않습니다");
+    }
+
+    @Test
+    @DisplayName("handleNotReadable()는 trailing token JSON 오류를 사람이 읽을 수 있게 변환한다")
+    void handleNotReadable_returnsReadableJsonMessage() {
+        GlobalExceptionHandler handler = new GlobalExceptionHandler(List.of(errorAlertNotifier));
+        HttpServletRequest request = request("POST", "/api/v1/documents");
+        HttpMessageNotReadableException exception = new HttpMessageNotReadableException(
+                "JSON parse error: Trailing token (`JsonToken.START_OBJECT`) found after value",
+                new MockHttpInputMessage(new byte[0])
+        );
+
+        var response = handler.handleNotReadable(exception, request);
+
+        assertThat(response.getStatusCode()).isEqualTo(ErrorCode.REQUEST_BODY_INVALID_JSON.getStatus());
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().msg()).isEqualTo("요청 본문에는 JSON 객체 하나만 포함되어야 합니다");
+    }
+
     private HttpServletRequest request(String method, String uri) {
         MockHttpServletRequest request = new MockHttpServletRequest(method, uri);
         request.setRemoteAddr("127.0.0.1");
         return request;
+    }
+
+    @SuppressWarnings("unused")
+    private static class TestController {
+        private void create(String value) {
+        }
     }
 }

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/CreateDocumentParagraphRequest.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/CreateDocumentParagraphRequest.java
@@ -1,7 +1,11 @@
 package or.hyu.ssd.domain.document.controller.dto;
 
+import jakarta.validation.constraints.NotBlank;
+
 public record CreateDocumentParagraphRequest(
+        @NotBlank(message = "문단 내용은 필수입니다")
         String content,
+        @NotBlank(message = "문단 역할은 필수입니다")
         String role,
         Integer blockId
 ) {}

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/CreateDocumentRequest.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/CreateDocumentRequest.java
@@ -1,12 +1,15 @@
 package or.hyu.ssd.domain.document.controller.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.PositiveOrZero;
 import java.util.List;
 
 public record CreateDocumentRequest(
         String title,
         @NotBlank(message = "내용은 필수입니다")
         String text,
-        List<CreateDocumentParagraphRequest> paragraphs,
+        List<@Valid CreateDocumentParagraphRequest> paragraphs,
+        @PositiveOrZero(message = "폴더 ID는 0 이상이어야 합니다")
         Long folderId
 ) {}

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/CreateFolderRequest.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/CreateFolderRequest.java
@@ -1,10 +1,12 @@
 package or.hyu.ssd.domain.document.controller.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.PositiveOrZero;
 
 public record CreateFolderRequest(
         @NotBlank(message = "폴더명은 필수입니다")
         String name,
         String color,
+        @PositiveOrZero(message = "상위 폴더 ID는 0 이상이어야 합니다")
         Long parentId
 ) {}

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/DocumentParagraphDto.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/DocumentParagraphDto.java
@@ -1,8 +1,14 @@
 package or.hyu.ssd.domain.document.controller.dto;
 
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+
 public record DocumentParagraphDto(
+        @NotBlank(message = "문단 내용은 필수입니다")
         String content,
+        @NotBlank(message = "문단 역할은 필수입니다")
         String role,
+        @Min(value = 1, message = "문단 페이지 번호는 1 이상이어야 합니다")
         int pageNumber,
         Integer blockId
 ) {}

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/ExternalDocumentIdRequest.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/ExternalDocumentIdRequest.java
@@ -2,9 +2,11 @@ package or.hyu.ssd.domain.document.controller.dto;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 
 public record ExternalDocumentIdRequest(
-        @NotBlank
+        @NotBlank(message = "docId는 필수입니다")
+        @Pattern(regexp = "^[1-9]\\d*$", message = "docId는 1 이상의 숫자여야 합니다")
         @JsonAlias("doc_id")
         String docId
 ) {

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/UpdateDocumentRequest.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/UpdateDocumentRequest.java
@@ -1,5 +1,8 @@
 package or.hyu.ssd.domain.document.controller.dto;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.PositiveOrZero;
+
 import java.util.List;
 
 public record UpdateDocumentRequest(
@@ -7,7 +10,8 @@ public record UpdateDocumentRequest(
         String text,
         String summary,
         String details,
+        @PositiveOrZero(message = "폴더 ID는 0 이상이어야 합니다")
         Long folderId,
         Boolean bookmark,
-        List<DocumentParagraphDto> paragraphs
+        List<@Valid DocumentParagraphDto> paragraphs
 ) {}

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/UpdateFolderRequest.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/UpdateFolderRequest.java
@@ -1,7 +1,10 @@
 package or.hyu.ssd.domain.document.controller.dto;
 
+import jakarta.validation.constraints.PositiveOrZero;
+
 public record UpdateFolderRequest(
         String name,
         String color,
+        @PositiveOrZero(message = "상위 폴더 ID는 0 이상이어야 합니다")
         Long parentId
 ) {}

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/document/service/DocumentCommentService.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/document/service/DocumentCommentService.java
@@ -33,6 +33,7 @@ public class DocumentCommentService {
     public DocumentCommentResponse create(Long documentId, CustomUserDetails user, DocumentCommentRequest request) {
         Document doc = getDocument(documentId);
         ensureAuthenticated(user);
+        ensureDocumentOwner(doc, user);
         int blockId = request.blockId();
 
         // 문서와 blockId를 통해서 지정된 blockId를 조회합니다
@@ -66,6 +67,7 @@ public class DocumentCommentService {
         // 문서 ID로 문서를 가져옵니다
         Document doc = getDocument(documentId);
         ensureAuthenticated(user);
+        ensureDocumentOwner(doc, user);
 
         // 문서에 매핑된 DocumentParagraph를 blockId순으로 정렬하여 가져옵니다 -> 주석의 본문 내용을 가져오기 위함
         Map<Integer, String> blockContentMap = documentParagraphRepository
@@ -110,6 +112,15 @@ public class DocumentCommentService {
         }
         if (!comment.getMember().getId().equals(user.getMember().getId())) {
             throw new UserExceptionHandler(ErrorCode.COMMENT_FORBIDDEN);
+        }
+    }
+
+    private void ensureDocumentOwner(Document document, CustomUserDetails user) {
+        if (document.getMember() == null || user.getMember() == null) {
+            throw new UserExceptionHandler(ErrorCode.DOCUMENT_FORBIDDEN);
+        }
+        if (!document.getMember().getId().equals(user.getMember().getId())) {
+            throw new UserExceptionHandler(ErrorCode.DOCUMENT_FORBIDDEN);
         }
     }
 

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/document/service/DocumentService.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/document/service/DocumentService.java
@@ -53,6 +53,7 @@ public class DocumentService {
         if (user == null || user.getMember() == null) {
             throw new UserExceptionHandler(ErrorCode.MEMBER_NOT_FOUND);
         }
+        validateFolderId(req.folderId());
 
         String title = resolveTitle(req.title(), req.text(), req.paragraphs());
         Folder folder = resolveFolderOrNull(user, req.folderId());
@@ -73,6 +74,7 @@ public class DocumentService {
         if (!doc.getMember().getId().equals(user.getMember().getId())) {
             throw new UserExceptionHandler(ErrorCode.DOCUMENT_FORBIDDEN);
         }
+        validateUpdateRequest(req);
 
         doc.updateIfPresent(req.title(), req.text(), req.summary(), req.details(), req.bookmark());
         if (req.folderId() != null) {
@@ -209,6 +211,42 @@ public class DocumentService {
             return fromText;
         }
         return "Untitled";
+    }
+
+    private void validateUpdateRequest(UpdateDocumentRequest req) {
+        if (req == null) {
+            throw new UserExceptionHandler(ErrorCode.REQUEST_BODY_INVALID_VALUE, "수정 요청 본문이 비어 있습니다");
+        }
+        if (isBlankProvided(req.title())) {
+            throw new UserExceptionHandler(ErrorCode.REQUEST_BODY_INVALID_VALUE, "제목은 공백일 수 없습니다");
+        }
+        if (isBlankProvided(req.text())) {
+            throw new UserExceptionHandler(ErrorCode.REQUEST_BODY_INVALID_VALUE, "내용은 공백일 수 없습니다");
+        }
+        validateFolderId(req.folderId());
+        if (!hasChanges(req)) {
+            throw new UserExceptionHandler(ErrorCode.REQUEST_BODY_INVALID_VALUE, "수정할 값을 하나 이상 입력해 주세요");
+        }
+    }
+
+    private boolean hasChanges(UpdateDocumentRequest req) {
+        return req.title() != null
+                || req.text() != null
+                || req.summary() != null
+                || req.details() != null
+                || req.folderId() != null
+                || req.bookmark() != null
+                || req.paragraphs() != null;
+    }
+
+    private void validateFolderId(Long folderId) {
+        if (folderId != null && folderId < 0L) {
+            throw new UserExceptionHandler(ErrorCode.REQUEST_BODY_INVALID_VALUE, "폴더 ID는 0 이상이어야 합니다");
+        }
+    }
+
+    private boolean isBlankProvided(String value) {
+        return value != null && value.trim().isEmpty();
     }
 
     private String trimOrNull(String value) {

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/document/service/ExternalAiService.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/document/service/ExternalAiService.java
@@ -199,7 +199,7 @@ public class ExternalAiService {
             }
             return docId;
         } catch (Exception e) {
-            throw new UserExceptionHandler(ErrorCode.DOCUMENT_NOT_FOUND);
+            throw new UserExceptionHandler(ErrorCode.REQUEST_BODY_INVALID_VALUE, "docId는 1 이상의 숫자여야 합니다");
         }
     }
 

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/document/service/FolderService.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/document/service/FolderService.java
@@ -33,6 +33,7 @@ public class FolderService {
 
     public CreateFolderResponse create(CustomUserDetails user, CreateFolderRequest request) {
         ensureAuthenticated(user);
+        validateParentId(request.parentId());
 
         String name = request.name().trim();
         String color = trimOrNull(request.color());
@@ -44,6 +45,7 @@ public class FolderService {
 
     public UpdateFolderResponse update(Long folderId, CustomUserDetails user, UpdateFolderRequest request) {
         Folder folder = getFolderOwned(folderId, user);
+        validateUpdateRequest(request);
 
         String name = trimOrNull(request.name());
         String color = trimOrNull(request.color());
@@ -176,6 +178,25 @@ public class FolderService {
         }
         String trimmed = value.trim();
         return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    private void validateUpdateRequest(UpdateFolderRequest request) {
+        if (request == null) {
+            throw new UserExceptionHandler(ErrorCode.REQUEST_BODY_INVALID_VALUE, "수정 요청 본문이 비어 있습니다");
+        }
+        if (request.name() != null && request.name().trim().isEmpty()) {
+            throw new UserExceptionHandler(ErrorCode.REQUEST_BODY_INVALID_VALUE, "폴더명은 공백일 수 없습니다");
+        }
+        validateParentId(request.parentId());
+        if (request.name() == null && request.color() == null && request.parentId() == null) {
+            throw new UserExceptionHandler(ErrorCode.REQUEST_BODY_INVALID_VALUE, "수정할 값을 하나 이상 입력해 주세요");
+        }
+    }
+
+    private void validateParentId(Long parentId) {
+        if (parentId != null && parentId < 0L) {
+            throw new UserExceptionHandler(ErrorCode.REQUEST_BODY_INVALID_VALUE, "상위 폴더 ID는 0 이상이어야 합니다");
+        }
     }
 
     private List<FolderListItemResponse> toFolderItems(Long memberId, List<Folder> folders) {

--- a/ssd-domain/src/test/java/or/hyu/ssd/domain/document/service/DocumentCommentServiceTest.java
+++ b/ssd-domain/src/test/java/or/hyu/ssd/domain/document/service/DocumentCommentServiceTest.java
@@ -1,0 +1,89 @@
+package or.hyu.ssd.domain.document.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import or.hyu.ssd.domain.document.controller.dto.DocumentCommentRequest;
+import or.hyu.ssd.domain.document.entity.Document;
+import or.hyu.ssd.domain.document.repository.DocumentCommentRepository;
+import or.hyu.ssd.domain.document.repository.DocumentParagraphRepository;
+import or.hyu.ssd.domain.document.repository.DocumentRepository;
+import or.hyu.ssd.domain.member.entity.Member;
+import or.hyu.ssd.domain.member.entity.Role;
+import or.hyu.ssd.domain.member.service.CustomUserDetails;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DocumentCommentServiceTest {
+
+    @Mock
+    private DocumentRepository documentRepository;
+    @Mock
+    private DocumentParagraphRepository documentParagraphRepository;
+    @Mock
+    private DocumentCommentRepository documentCommentRepository;
+
+    @InjectMocks
+    private DocumentCommentService documentCommentService;
+
+    @Test
+    @DisplayName("create()는 문서 소유자가 아니면 주석 생성을 거부한다")
+    void create_rejectsNonOwner() {
+        Member owner = member(1L, "owner@example.com");
+        Member other = member(2L, "other@example.com");
+        Document document = document(10L, owner);
+        when(documentRepository.findById(10L)).thenReturn(Optional.of(document));
+
+        assertThatThrownBy(() -> documentCommentService.create(
+                10L,
+                new CustomUserDetails(other),
+                new DocumentCommentRequest(1, "주석")
+        ))
+                .isInstanceOf(or.hyu.ssd.global.api.handler.UserExceptionHandler.class)
+                .hasMessage("해당 문서를 수정할 권한이 없습니다");
+    }
+
+    @Test
+    @DisplayName("list()는 문서 소유자가 아니면 주석 조회를 거부한다")
+    void list_rejectsNonOwner() {
+        Member owner = member(1L, "owner@example.com");
+        Member other = member(2L, "other@example.com");
+        Document document = document(10L, owner);
+        when(documentRepository.findById(10L)).thenReturn(Optional.of(document));
+
+        assertThatThrownBy(() -> documentCommentService.list(
+                10L,
+                new CustomUserDetails(other)
+        ))
+                .isInstanceOf(or.hyu.ssd.global.api.handler.UserExceptionHandler.class)
+                .hasMessage("해당 문서를 수정할 권한이 없습니다");
+    }
+
+    private Document document(Long id, Member member) {
+        return Document.builder()
+                .id(id)
+                .title("문서")
+                .content("본문")
+                .bookmark(false)
+                .member(member)
+                .build();
+    }
+
+    private Member member(Long id, String email) {
+        return Member.builder()
+                .id(id)
+                .name("테스터")
+                .email(email)
+                .profileImageUrl("")
+                .profileImageKey(null)
+                .role(Role.ROLE_AUTHOR)
+                .build();
+    }
+}

--- a/ssd-domain/src/test/java/or/hyu/ssd/domain/document/service/DocumentServiceTest.java
+++ b/ssd-domain/src/test/java/or/hyu/ssd/domain/document/service/DocumentServiceTest.java
@@ -6,6 +6,7 @@ import or.hyu.ssd.domain.document.controller.dto.CreateDocumentResponse;
 import or.hyu.ssd.domain.document.entity.Document;
 import or.hyu.ssd.domain.document.entity.DocumentParagraph;
 import or.hyu.ssd.domain.document.repository.CheckListRepository;
+import or.hyu.ssd.domain.document.repository.DocumentAiCheckSnapshotRepository;
 import or.hyu.ssd.domain.document.repository.DocumentCommentRepository;
 import or.hyu.ssd.domain.document.repository.DocumentLogRepository;
 import or.hyu.ssd.domain.document.repository.DocumentParagraphRepository;
@@ -26,8 +27,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -41,6 +44,8 @@ class DocumentServiceTest {
     private CheckListRepository checkListRepository;
     @Mock
     private EvaluatorCheckListRepository evaluatorCheckListRepository;
+    @Mock
+    private DocumentAiCheckSnapshotRepository documentAiCheckSnapshotRepository;
     @Mock
     private DocumentParagraphRepository documentParagraphRepository;
     @Mock
@@ -108,6 +113,64 @@ class DocumentServiceTest {
                 .extracting(DocumentParagraph::getBlockId)
                 .containsExactly(1, 2);
         assertThat(response.id()).isEqualTo(42L);
+    }
+
+    @Test
+    @DisplayName("updateDocument()는 수정할 값이 하나도 없으면 예외를 던진다")
+    void updateDocument_throwsWhenRequestHasNoChanges() {
+        Member member = member(1L);
+        CustomUserDetails user = new CustomUserDetails(member);
+        Document document = document(42L, member);
+        when(documentRepository.findById(42L)).thenReturn(Optional.of(document));
+
+        assertThatThrownBy(() -> documentService.updateDocument(
+                42L,
+                user,
+                new or.hyu.ssd.domain.document.controller.dto.UpdateDocumentRequest(
+                        null, null, null, null, null, null, null
+                )
+        ))
+                .isInstanceOf(or.hyu.ssd.global.api.handler.UserExceptionHandler.class)
+                .hasMessage("수정할 값을 하나 이상 입력해 주세요");
+    }
+
+    @Test
+    @DisplayName("updateDocument()는 공백 제목이나 공백 본문을 거부한다")
+    void updateDocument_rejectsBlankFields() {
+        Member member = member(1L);
+        CustomUserDetails user = new CustomUserDetails(member);
+        Document document = document(42L, member);
+        when(documentRepository.findById(42L)).thenReturn(Optional.of(document));
+
+        assertThatThrownBy(() -> documentService.updateDocument(
+                42L,
+                user,
+                new or.hyu.ssd.domain.document.controller.dto.UpdateDocumentRequest(
+                        "   ", null, null, null, null, null, null
+                )
+        ))
+                .isInstanceOf(or.hyu.ssd.global.api.handler.UserExceptionHandler.class)
+                .hasMessage("제목은 공백일 수 없습니다");
+
+        assertThatThrownBy(() -> documentService.updateDocument(
+                42L,
+                user,
+                new or.hyu.ssd.domain.document.controller.dto.UpdateDocumentRequest(
+                        null, "   ", null, null, null, null, null
+                )
+        ))
+                .isInstanceOf(or.hyu.ssd.global.api.handler.UserExceptionHandler.class)
+                .hasMessage("내용은 공백일 수 없습니다");
+    }
+
+    private Document document(Long id, Member member) {
+        return Document.builder()
+                .id(id)
+                .title("문서 제목")
+                .content("문서 본문")
+                .bookmark(false)
+                .member(member)
+                .build();
     }
 
     private Member member(Long id) {

--- a/ssd-domain/src/test/java/or/hyu/ssd/domain/document/service/ExternalAiServiceTest.java
+++ b/ssd-domain/src/test/java/or/hyu/ssd/domain/document/service/ExternalAiServiceTest.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -165,6 +166,17 @@ class ExternalAiServiceTest {
         assertThat(response.checkList()).containsEntry("market_definition_is_correct", true);
         assertThat(document.isChecklistProblemIsClear()).isTrue();
         assertThat(document.isChecklistMarketDefinitionIsCorrect()).isTrue();
+    }
+
+    @Test
+    @DisplayName("evaluate()는 숫자가 아닌 docId를 400 예외로 거부한다")
+    void evaluate_rejectsInvalidDocId() {
+        Member member = member(1L);
+        CustomUserDetails user = new CustomUserDetails(member);
+
+        assertThatThrownBy(() -> externalAiService.evaluate(new ExternalDocumentIdRequest("abc"), user))
+                .isInstanceOf(or.hyu.ssd.global.api.handler.UserExceptionHandler.class)
+                .hasMessage("docId는 1 이상의 숫자여야 합니다");
     }
 
     private Document document(Long id, Member member) {

--- a/ssd-domain/src/test/java/or/hyu/ssd/domain/document/service/FolderServiceTest.java
+++ b/ssd-domain/src/test/java/or/hyu/ssd/domain/document/service/FolderServiceTest.java
@@ -17,8 +17,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Sort;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -89,6 +91,40 @@ class FolderServiceTest {
         assertThat(result.folders().get(1).parentId()).isEqualTo(1L);
         assertThat(result.documents().get(0).folderId()).isEqualTo(1L);
         assertThat(result.documents().get(1).folderId()).isEqualTo(11L);
+    }
+
+    @Test
+    @DisplayName("update()는 수정할 값이 하나도 없으면 예외를 던진다")
+    void update_throwsWhenNoChangesProvided() {
+        Member member = member(1L);
+        CustomUserDetails user = new CustomUserDetails(member);
+        Folder folder = folder(1L, "작성하기", null, member);
+        when(folderRepository.findById(1L)).thenReturn(Optional.of(folder));
+
+        assertThatThrownBy(() -> folderService.update(
+                1L,
+                user,
+                new or.hyu.ssd.domain.document.controller.dto.UpdateFolderRequest(null, null, null)
+        ))
+                .isInstanceOf(or.hyu.ssd.global.api.handler.UserExceptionHandler.class)
+                .hasMessage("수정할 값을 하나 이상 입력해 주세요");
+    }
+
+    @Test
+    @DisplayName("update()는 공백 폴더명을 거부한다")
+    void update_rejectsBlankName() {
+        Member member = member(1L);
+        CustomUserDetails user = new CustomUserDetails(member);
+        Folder folder = folder(1L, "작성하기", null, member);
+        when(folderRepository.findById(1L)).thenReturn(Optional.of(folder));
+
+        assertThatThrownBy(() -> folderService.update(
+                1L,
+                user,
+                new or.hyu.ssd.domain.document.controller.dto.UpdateFolderRequest("   ", null, null)
+        ))
+                .isInstanceOf(or.hyu.ssd.global.api.handler.UserExceptionHandler.class)
+                .hasMessage("폴더명은 공백일 수 없습니다");
     }
 
     private Member member(Long id) {


### PR DESCRIPTION
## 📣 Related Issue

- close #89


<br><br>

## 📝 Summary

- 요청 검증/파라미터/JSON 파싱/인가 예외를 `ApiResponse` 형식으로 세분화했습니다.
- Security 403 응답을 커스텀 핸들러로 통일했습니다.
- 사람이 이해할 수 있는 예외 메시지와 테스트를 추가했습니다.


<br><br>

## 🙏 Details

- `GlobalExceptionHandler`에 아래 예외 처리를 추가했습니다.
  - `MethodArgumentNotValidException`
  - `BindException`
  - `ConstraintViolationException`
  - `MethodArgumentTypeMismatchException`
  - `MissingServletRequestParameterException`
  - `MissingRequestHeaderException`
  - `HttpMediaTypeNotSupportedException`
  - `AccessDeniedException`
- `HttpMessageNotReadableException`은 trailing token, 빈 body, 역직렬화 타입 오류를 사람이 읽을 수 있는 메시지로 변환합니다.
- `ApiResponse.fail(ErrorCode, String)` 오버로드를 추가해 기본 에러코드는 유지하면서 상세 메시지를 반환하도록 했습니다.
- `AccessDeniedHandlerImpl`를 추가하고 `SecurityConfig`에 연결해 인증은 401, 인가는 403으로 JSON 응답을 일관되게 내리도록 정리했습니다.
- 테스트를 추가해 검증 메시지, 타입 mismatch, JSON trailing token, 403 응답을 고정했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 접근 거부 시 JSON 오류 응답 제공
  * 요청 검증 오류 종류(파라미터/헤더/바디/미지원 미디어타입)별 세분화된 메시지 및 에러 코드 추가

* **버그 픽스 / 개선**
  * JSON 파싱 및 타입 불일치 시 사용자 친화적 오류 메시지 개선
  * 여러 컨트롤러 및 DTO에 입력 검증 강화(경계/양수/비어있음 검사)

* **테스트**
  * 예외 처리 및 권한/검증 관련 단위 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->