### PR TITLE
[FEATURE] 리뷰 & 기록 API 구현

### DIFF
--- a/ssd-api/src/main/java/or/hyu/ssd/domain/document/controller/DocumentLogController.java
+++ b/ssd-api/src/main/java/or/hyu/ssd/domain/document/controller/DocumentLogController.java
@@ -1,0 +1,58 @@
+package or.hyu.ssd.domain.document.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Positive;
+import lombok.RequiredArgsConstructor;
+import or.hyu.ssd.domain.document.controller.dto.DocumentLogResponse;
+import or.hyu.ssd.domain.document.service.DocumentLogService;
+import or.hyu.ssd.domain.member.service.CustomUserDetails;
+import or.hyu.ssd.global.api.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+@Validated
+@Tag(name = "기록 API", description = "문서 생성/수정 시 자동 생성되는 기록 조회")
+public class DocumentLogController {
+
+    private final DocumentLogService documentLogService;
+
+    @GetMapping("/v1/documents/{documentId}/logs")
+    @Operation(
+            summary = "문서 기록 조회",
+            description = """
+                    ### 개요
+                    - 문서 생성/수정 시 자동 생성된 기록을 날짜별로 조회합니다.
+                    - 별도의 기록 생성/수정 API는 제공하지 않습니다.
+
+                    ### 인증
+                    - Authorization: Bearer {accessToken} (문서 작성자만)
+
+                    ### 요청
+                    - Path: /api/v1/documents/{documentId}/logs
+
+                    ### 응답
+                    - 200 OK
+                    - data.documentId: 문서 ID
+                    - data.records[].savedDate: 저장 날짜
+                    - data.records[].logs[].savedTime: 저장 시간
+                    - data.records[].logs[].editorName: 저장한 사람 이름
+                    - data.records[].logs[].editorEmail: 저장한 사람 이메일
+                    """
+    )
+    public ResponseEntity<ApiResponse<DocumentLogResponse>> list(
+            @PathVariable @Positive(message = "문서 ID는 1 이상이어야 합니다") Long documentId,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        DocumentLogResponse response = documentLogService.list(documentId, user);
+        return ResponseEntity.ok(ApiResponse.ok(response, "기록이 조회되었습니다"));
+    }
+}

--- a/ssd-api/src/main/java/or/hyu/ssd/domain/document/controller/EvaluatorReviewController.java
+++ b/ssd-api/src/main/java/or/hyu/ssd/domain/document/controller/EvaluatorReviewController.java
@@ -1,0 +1,138 @@
+package or.hyu.ssd.domain.document.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
+import lombok.RequiredArgsConstructor;
+import or.hyu.ssd.domain.document.controller.dto.EvaluatorReviewCreateRequest;
+import or.hyu.ssd.domain.document.controller.dto.EvaluatorReviewDetailResponse;
+import or.hyu.ssd.domain.document.controller.dto.EvaluatorReviewIdResponse;
+import or.hyu.ssd.domain.document.controller.dto.EvaluatorReviewListResponse;
+import or.hyu.ssd.domain.document.controller.dto.EvaluatorReviewUpdateRequest;
+import or.hyu.ssd.domain.document.service.EvaluatorReviewService;
+import or.hyu.ssd.domain.member.service.CustomUserDetails;
+import or.hyu.ssd.global.api.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+@Validated
+@Tag(name = "리뷰 API", description = "문서 평가 리뷰 생성/수정/조회/삭제")
+public class EvaluatorReviewController {
+
+    private final EvaluatorReviewService evaluatorReviewService;
+
+    @PostMapping("/v1/documents/{documentId}/reviews")
+    @Operation(
+            summary = "리뷰 생성",
+            description = """
+                    ### 개요
+                    - 로그인한 사용자가 문서에 대해 자신의 리뷰 1건을 생성합니다.
+
+                    ### 인증
+                    - Authorization: Bearer {accessToken}
+
+                    ### 요청
+                    - Path: /api/v1/documents/{documentId}/reviews
+                    - Body(JSON)
+                      - feasibility: 사업타당성 점수 (0~100)
+                      - differentiation: 사업차별성 점수 (0~100)
+                      - financial: 재무적정성 점수 (0~100)
+                      - comment: 상세의견
+
+                    ### 제약
+                    - 한 사용자는 문서당 리뷰 1건만 작성할 수 있습니다.
+                    - 이미 리뷰가 있으면 409 Conflict를 반환합니다.
+                    """
+    )
+    public ResponseEntity<ApiResponse<EvaluatorReviewIdResponse>> create(
+            @PathVariable @Positive(message = "문서 ID는 1 이상이어야 합니다") Long documentId,
+            @Valid @RequestBody EvaluatorReviewCreateRequest request,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        EvaluatorReviewIdResponse response = evaluatorReviewService.create(documentId, user, request);
+        return ResponseEntity.ok(ApiResponse.ok(response, "리뷰가 저장되었습니다"));
+    }
+
+    @PutMapping("/v1/documents/{documentId}/reviews")
+    @Operation(
+            summary = "내 리뷰 수정",
+            description = """
+                    ### 개요
+                    - 로그인한 사용자가 자신이 작성한 리뷰를 수정합니다.
+
+                    ### 인증
+                    - Authorization: Bearer {accessToken}
+                    """
+    )
+    public ResponseEntity<ApiResponse<EvaluatorReviewDetailResponse>> update(
+            @PathVariable @Positive(message = "문서 ID는 1 이상이어야 합니다") Long documentId,
+            @Valid @RequestBody EvaluatorReviewUpdateRequest request,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        EvaluatorReviewDetailResponse response = evaluatorReviewService.update(documentId, user, request);
+        return ResponseEntity.ok(ApiResponse.ok(response, "리뷰가 수정되었습니다"));
+    }
+
+    @GetMapping("/v1/documents/{documentId}/reviews/me")
+    @Operation(
+            summary = "내 리뷰 상세 조회",
+            description = """
+                    ### 개요
+                    - 로그인한 사용자가 자신이 작성한 리뷰의 상세 정보를 조회합니다.
+                    """
+    )
+    public ResponseEntity<ApiResponse<EvaluatorReviewDetailResponse>> getMyReview(
+            @PathVariable @Positive(message = "문서 ID는 1 이상이어야 합니다") Long documentId,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        EvaluatorReviewDetailResponse response = evaluatorReviewService.getMyReview(documentId, user);
+        return ResponseEntity.ok(ApiResponse.ok(response, "리뷰가 조회되었습니다"));
+    }
+
+    @GetMapping("/v1/documents/{documentId}/reviews")
+    @Operation(
+            summary = "문서 리뷰 목록 조회",
+            description = """
+                    ### 개요
+                    - 문서 작성자가 해당 문서의 전체 리뷰 요약 목록을 조회합니다.
+                    - 모든 리뷰의 종합평점 평균과, 각 평가자의 이름/종합평점을 함께 반환합니다.
+                    """
+    )
+    public ResponseEntity<ApiResponse<EvaluatorReviewListResponse>> list(
+            @PathVariable @Positive(message = "문서 ID는 1 이상이어야 합니다") Long documentId,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        EvaluatorReviewListResponse response = evaluatorReviewService.list(documentId, user);
+        return ResponseEntity.ok(ApiResponse.ok(response, "리뷰 목록이 조회되었습니다"));
+    }
+
+    @DeleteMapping("/v1/documents/{documentId}/reviews")
+    @Operation(
+            summary = "내 리뷰 삭제",
+            description = """
+                    ### 개요
+                    - 로그인한 사용자가 자신이 작성한 리뷰를 삭제합니다.
+                    - 삭제 후 문서 평균 점수는 즉시 재집계됩니다.
+                    """
+    )
+    public ResponseEntity<ApiResponse<String>> delete(
+            @PathVariable @Positive(message = "문서 ID는 1 이상이어야 합니다") Long documentId,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        evaluatorReviewService.delete(documentId, user);
+        return ResponseEntity.ok(ApiResponse.ok("리뷰가 삭제되었습니다"));
+    }
+}

--- a/ssd-core/src/main/java/or/hyu/ssd/global/api/ErrorCode.java
+++ b/ssd-core/src/main/java/or/hyu/ssd/global/api/ErrorCode.java
@@ -44,6 +44,8 @@ public enum ErrorCode {
 
     // 평가자 리뷰 예외
     REVIEW_INVALID_SCORE(HttpStatus.BAD_REQUEST, "REV40001", "리뷰 점수는 0~100 범위여야 합니다"),
+    REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "REV40401", "리뷰를 찾지 못했습니다"),
+    REVIEW_ALREADY_EXISTS(HttpStatus.CONFLICT, "REV40901", "이미 작성한 리뷰가 존재합니다"),
 
     // 외부 AI 연동 예외
     EXTERNAL_AI_CALL_FAILED(HttpStatus.BAD_GATEWAY, "AI50201", "외부 AI 서버 호출에 실패했습니다"),

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/DocumentLogDateGroupResponse.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/DocumentLogDateGroupResponse.java
@@ -1,0 +1,12 @@
+package or.hyu.ssd.domain.document.controller.dto;
+
+import java.util.List;
+
+public record DocumentLogDateGroupResponse(
+        String savedDate,
+        List<DocumentLogItemResponse> logs
+) {
+    public static DocumentLogDateGroupResponse of(String savedDate, List<DocumentLogItemResponse> logs) {
+        return new DocumentLogDateGroupResponse(savedDate, logs == null ? List.of() : logs);
+    }
+}

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/DocumentLogItemResponse.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/DocumentLogItemResponse.java
@@ -1,0 +1,29 @@
+package or.hyu.ssd.domain.document.controller.dto;
+
+import or.hyu.ssd.domain.document.entity.DocumentLog;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public record DocumentLogItemResponse(
+        String savedTime,
+        String editorName,
+        String editorEmail
+) {
+    private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
+
+    public static DocumentLogItemResponse of(DocumentLog log) {
+        return new DocumentLogItemResponse(
+                formatTime(log.getCreatedAt()),
+                log.getEditorName(),
+                log.getEditorEmail()
+        );
+    }
+
+    private static String formatTime(LocalDateTime createdAt) {
+        if (createdAt == null) {
+            return "";
+        }
+        return createdAt.format(TIME_FORMATTER);
+    }
+}

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/DocumentLogResponse.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/DocumentLogResponse.java
@@ -1,0 +1,12 @@
+package or.hyu.ssd.domain.document.controller.dto;
+
+import java.util.List;
+
+public record DocumentLogResponse(
+        Long documentId,
+        List<DocumentLogDateGroupResponse> records
+) {
+    public static DocumentLogResponse of(Long documentId, List<DocumentLogDateGroupResponse> records) {
+        return new DocumentLogResponse(documentId, records == null ? List.of() : records);
+    }
+}

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/EvaluatorReviewCreateRequest.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/EvaluatorReviewCreateRequest.java
@@ -1,0 +1,27 @@
+package or.hyu.ssd.domain.document.controller.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record EvaluatorReviewCreateRequest(
+        @NotNull(message = "사업타당성 점수는 필수입니다")
+        @Min(value = 0, message = "사업타당성 점수는 0 이상이어야 합니다")
+        @Max(value = 100, message = "사업타당성 점수는 100 이하여야 합니다")
+        Integer feasibility,
+
+        @NotNull(message = "사업차별성 점수는 필수입니다")
+        @Min(value = 0, message = "사업차별성 점수는 0 이상이어야 합니다")
+        @Max(value = 100, message = "사업차별성 점수는 100 이하여야 합니다")
+        Integer differentiation,
+
+        @NotNull(message = "재무적정성 점수는 필수입니다")
+        @Min(value = 0, message = "재무적정성 점수는 0 이상이어야 합니다")
+        @Max(value = 100, message = "재무적정성 점수는 100 이하여야 합니다")
+        Integer financial,
+
+        @NotBlank(message = "상세의견은 필수입니다")
+        String comment
+) {
+}

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/EvaluatorReviewDetailResponse.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/EvaluatorReviewDetailResponse.java
@@ -1,0 +1,31 @@
+package or.hyu.ssd.domain.document.controller.dto;
+
+import or.hyu.ssd.domain.document.entity.EvaluatorReview;
+
+import java.time.LocalDateTime;
+
+public record EvaluatorReviewDetailResponse(
+        Long reviewId,
+        String reviewerName,
+        String reviewerEmail,
+        LocalDateTime changedAt,
+        int feasibility,
+        int differentiation,
+        int financial,
+        double totalScore,
+        String comment
+) {
+    public static EvaluatorReviewDetailResponse of(EvaluatorReview review) {
+        return new EvaluatorReviewDetailResponse(
+                review.getId(),
+                review.getReviewer() == null ? null : review.getReviewer().getName(),
+                review.getReviewer() == null ? null : review.getReviewer().getEmail(),
+                review.getUpdatedAt(),
+                review.getScoreFeasibility(),
+                review.getScoreDifferentiation(),
+                review.getScoreFinancial(),
+                review.getScoreTotal(),
+                review.getComment()
+        );
+    }
+}

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/EvaluatorReviewIdResponse.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/EvaluatorReviewIdResponse.java
@@ -1,0 +1,7 @@
+package or.hyu.ssd.domain.document.controller.dto;
+
+public record EvaluatorReviewIdResponse(Long id) {
+    public static EvaluatorReviewIdResponse of(Long id) {
+        return new EvaluatorReviewIdResponse(id);
+    }
+}

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/EvaluatorReviewListItemResponse.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/EvaluatorReviewListItemResponse.java
@@ -1,0 +1,15 @@
+package or.hyu.ssd.domain.document.controller.dto;
+
+import or.hyu.ssd.domain.document.entity.EvaluatorReview;
+
+public record EvaluatorReviewListItemResponse(
+        String reviewerName,
+        double totalScore
+) {
+    public static EvaluatorReviewListItemResponse of(EvaluatorReview review) {
+        return new EvaluatorReviewListItemResponse(
+                review.getReviewer() == null ? null : review.getReviewer().getName(),
+                review.getScoreTotal()
+        );
+    }
+}

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/EvaluatorReviewListResponse.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/EvaluatorReviewListResponse.java
@@ -1,0 +1,14 @@
+package or.hyu.ssd.domain.document.controller.dto;
+
+import java.util.List;
+
+public record EvaluatorReviewListResponse(
+        Long documentId,
+        double averageTotalScore,
+        int reviewCount,
+        List<EvaluatorReviewListItemResponse> reviews
+) {
+    public static EvaluatorReviewListResponse of(Long documentId, double averageTotalScore, int reviewCount, List<EvaluatorReviewListItemResponse> reviews) {
+        return new EvaluatorReviewListResponse(documentId, averageTotalScore, reviewCount, reviews == null ? List.of() : reviews);
+    }
+}

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/EvaluatorReviewUpdateRequest.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/EvaluatorReviewUpdateRequest.java
@@ -1,0 +1,27 @@
+package or.hyu.ssd.domain.document.controller.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record EvaluatorReviewUpdateRequest(
+        @NotNull(message = "사업타당성 점수는 필수입니다")
+        @Min(value = 0, message = "사업타당성 점수는 0 이상이어야 합니다")
+        @Max(value = 100, message = "사업타당성 점수는 100 이하여야 합니다")
+        Integer feasibility,
+
+        @NotNull(message = "사업차별성 점수는 필수입니다")
+        @Min(value = 0, message = "사업차별성 점수는 0 이상이어야 합니다")
+        @Max(value = 100, message = "사업차별성 점수는 100 이하여야 합니다")
+        Integer differentiation,
+
+        @NotNull(message = "재무적정성 점수는 필수입니다")
+        @Min(value = 0, message = "재무적정성 점수는 0 이상이어야 합니다")
+        @Max(value = 100, message = "재무적정성 점수는 100 이하여야 합니다")
+        Integer financial,
+
+        @NotBlank(message = "상세의견은 필수입니다")
+        String comment
+) {
+}

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/document/entity/DocumentLog.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/document/entity/DocumentLog.java
@@ -27,6 +27,10 @@ public class DocumentLog extends BaseEntity {
     @Column(name = "editor_name", nullable = false, length = 100)
     private String editorName;
 
+    @Comment("수정한 사용자 이메일 (입력: member.email)")
+    @Column(name = "editor_email", length = 150)
+    private String editorEmail;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "document_id", nullable = false)
     private Document document;
@@ -34,9 +38,10 @@ public class DocumentLog extends BaseEntity {
     @Version
     private Long version;
 
-    public static DocumentLog of(String editorName, Document document) {
+    public static DocumentLog of(String editorName, String editorEmail, Document document) {
         return DocumentLog.builder()
                 .editorName(editorName)
+                .editorEmail(editorEmail)
                 .document(document)
                 .build();
     }

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/document/repository/DocumentLogRepository.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/document/repository/DocumentLogRepository.java
@@ -8,7 +8,7 @@ import java.util.List;
 public interface DocumentLogRepository {
     DocumentLog save(DocumentLog log);
 
-    List<DocumentLog> findAllByDocumentOrderByCreatedAtAsc(Document document);
+    List<DocumentLog> findAllByDocumentOrderByCreatedAtDesc(Document document);
 
     void deleteAllByDocument(Document document);
 }

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/document/repository/EvaluatorReviewRepository.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/document/repository/EvaluatorReviewRepository.java
@@ -12,7 +12,13 @@ public interface EvaluatorReviewRepository {
 
     List<EvaluatorReview> findAllByDocument(Document document);
 
+    List<EvaluatorReview> findAllByDocumentOrderByUpdatedAtDesc(Document document);
+
     boolean existsByDocumentAndReviewer(Document document, Member reviewer);
 
     EvaluatorReview save(EvaluatorReview review);
+
+    void delete(EvaluatorReview review);
+
+    void deleteAllByDocument(Document document);
 }

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/document/service/DocumentLogService.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/document/service/DocumentLogService.java
@@ -1,0 +1,70 @@
+package or.hyu.ssd.domain.document.service;
+
+import lombok.RequiredArgsConstructor;
+import or.hyu.ssd.domain.document.controller.dto.DocumentLogDateGroupResponse;
+import or.hyu.ssd.domain.document.controller.dto.DocumentLogItemResponse;
+import or.hyu.ssd.domain.document.controller.dto.DocumentLogResponse;
+import or.hyu.ssd.domain.document.entity.Document;
+import or.hyu.ssd.domain.document.entity.DocumentLog;
+import or.hyu.ssd.domain.document.repository.DocumentLogRepository;
+import or.hyu.ssd.domain.document.repository.DocumentRepository;
+import or.hyu.ssd.domain.member.service.CustomUserDetails;
+import or.hyu.ssd.global.api.ErrorCode;
+import or.hyu.ssd.global.api.handler.UserExceptionHandler;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class DocumentLogService {
+
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE;
+
+    private final DocumentRepository documentRepository;
+    private final DocumentLogRepository documentLogRepository;
+
+    public DocumentLogResponse list(Long documentId, CustomUserDetails user) {
+        Document document = getOwnedDocument(documentId, user);
+        List<DocumentLog> logs = documentLogRepository.findAllByDocumentOrderByCreatedAtDesc(document);
+
+        List<DocumentLogDateGroupResponse> records = new ArrayList<>();
+        LocalDate currentDate = null;
+        List<DocumentLogItemResponse> currentLogs = new ArrayList<>();
+
+        for (DocumentLog log : logs) {
+            LocalDate logDate = log.getCreatedAt() == null ? null : log.getCreatedAt().toLocalDate();
+            if (currentDate == null || !currentDate.equals(logDate)) {
+                if (currentDate != null) {
+                    records.add(DocumentLogDateGroupResponse.of(currentDate.format(DATE_FORMATTER), List.copyOf(currentLogs)));
+                }
+                currentDate = logDate;
+                currentLogs = new ArrayList<>();
+            }
+            currentLogs.add(DocumentLogItemResponse.of(log));
+        }
+
+        if (currentDate != null) {
+            records.add(DocumentLogDateGroupResponse.of(currentDate.format(DATE_FORMATTER), List.copyOf(currentLogs)));
+        }
+
+        return DocumentLogResponse.of(document.getId(), records);
+    }
+
+    private Document getOwnedDocument(Long documentId, CustomUserDetails user) {
+        Document document = documentRepository.findById(documentId)
+                .orElseThrow(() -> new UserExceptionHandler(ErrorCode.DOCUMENT_NOT_FOUND));
+        if (user == null || user.getMember() == null || document.getMember() == null) {
+            throw new UserExceptionHandler(ErrorCode.DOCUMENT_FORBIDDEN);
+        }
+        if (!document.getMember().getId().equals(user.getMember().getId())) {
+            throw new UserExceptionHandler(ErrorCode.DOCUMENT_FORBIDDEN);
+        }
+        return document;
+    }
+}

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/document/service/DocumentService.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/document/service/DocumentService.java
@@ -19,6 +19,7 @@ import or.hyu.ssd.domain.document.repository.DocumentCommentRepository;
 import or.hyu.ssd.domain.document.repository.DocumentLogRepository;
 import or.hyu.ssd.domain.document.repository.DocumentParagraphRepository;
 import or.hyu.ssd.domain.document.repository.EvaluatorCheckListRepository;
+import or.hyu.ssd.domain.document.repository.EvaluatorReviewRepository;
 import or.hyu.ssd.domain.document.repository.FolderRepository;
 import or.hyu.ssd.domain.document.repository.DocumentRepository;
 import or.hyu.ssd.domain.document.service.support.DocumentSort;
@@ -46,6 +47,7 @@ public class DocumentService {
     private final DocumentParagraphRepository documentParagraphRepository;
     private final DocumentCommentRepository documentCommentRepository;
     private final DocumentLogRepository documentLogRepository;
+    private final EvaluatorReviewRepository evaluatorReviewRepository;
     private final FolderRepository folderRepository;
     private final OptimisticRetryExecutor optimisticRetryExecutor;
 
@@ -106,6 +108,7 @@ public class DocumentService {
         documentParagraphRepository.deleteAllByDocument(doc);
         documentCommentRepository.deleteAllByDocument(doc);
         documentLogRepository.deleteAllByDocument(doc);
+        evaluatorReviewRepository.deleteAllByDocument(doc);
         documentRepository.delete(doc);
     }
 

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/document/service/DocumentService.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/document/service/DocumentService.java
@@ -310,7 +310,7 @@ public class DocumentService {
 
     private void saveDocumentLog(Document doc, CustomUserDetails user) {
         String editorName = resolveEditorName(user);
-        documentLogRepository.save(DocumentLog.of(editorName, doc));
+        documentLogRepository.save(DocumentLog.of(editorName, resolveEditorEmail(user), doc));
     }
 
     private String resolveEditorName(CustomUserDetails user) {
@@ -326,5 +326,13 @@ public class DocumentService {
             return email.trim();
         }
         return "Unknown";
+    }
+
+    private String resolveEditorEmail(CustomUserDetails user) {
+        if (user == null || user.getMember() == null) {
+            return null;
+        }
+        String email = user.getMember().getEmail();
+        return email == null || email.isBlank() ? null : email.trim();
     }
 }

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/document/service/EvaluatorReviewService.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/document/service/EvaluatorReviewService.java
@@ -83,8 +83,11 @@ public class EvaluatorReviewService {
                 .map(EvaluatorReviewListItemResponse::of)
                 .toList();
 
-        double averageTotalScore = document.getReviewTotalAvg() == null ? 0.0 : document.getReviewTotalAvg();
-        int reviewCount = document.getReviewCount() == null ? 0 : document.getReviewCount();
+        double averageTotalScore = reviews.stream()
+                .mapToDouble(EvaluatorReview::getScoreTotal)
+                .average()
+                .orElse(0.0);
+        int reviewCount = reviews.size();
 
         return EvaluatorReviewListResponse.of(document.getId(), averageTotalScore, reviewCount, items);
     }

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/document/service/EvaluatorReviewService.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/document/service/EvaluatorReviewService.java
@@ -1,0 +1,137 @@
+package or.hyu.ssd.domain.document.service;
+
+import lombok.RequiredArgsConstructor;
+import or.hyu.ssd.domain.document.controller.dto.EvaluatorReviewCreateRequest;
+import or.hyu.ssd.domain.document.controller.dto.EvaluatorReviewDetailResponse;
+import or.hyu.ssd.domain.document.controller.dto.EvaluatorReviewIdResponse;
+import or.hyu.ssd.domain.document.controller.dto.EvaluatorReviewListItemResponse;
+import or.hyu.ssd.domain.document.controller.dto.EvaluatorReviewListResponse;
+import or.hyu.ssd.domain.document.controller.dto.EvaluatorReviewUpdateRequest;
+import or.hyu.ssd.domain.document.entity.Document;
+import or.hyu.ssd.domain.document.entity.EvaluatorReview;
+import or.hyu.ssd.domain.document.repository.DocumentRepository;
+import or.hyu.ssd.domain.document.repository.EvaluatorReviewRepository;
+import or.hyu.ssd.domain.member.entity.Member;
+import or.hyu.ssd.domain.member.service.CustomUserDetails;
+import or.hyu.ssd.global.api.ErrorCode;
+import or.hyu.ssd.global.api.handler.UserExceptionHandler;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class EvaluatorReviewService {
+
+    private final EvaluatorReviewRepository evaluatorReviewRepository;
+    private final DocumentRepository documentRepository;
+
+    public EvaluatorReviewIdResponse create(Long documentId, CustomUserDetails user, EvaluatorReviewCreateRequest request) {
+        Document document = getDocument(documentId);
+        Member reviewer = getReviewer(user);
+
+        if (evaluatorReviewRepository.existsByDocumentAndReviewer(document, reviewer)) {
+            throw new UserExceptionHandler(ErrorCode.REVIEW_ALREADY_EXISTS);
+        }
+
+        EvaluatorReview review = EvaluatorReview.of(
+                request.feasibility(),
+                request.differentiation(),
+                request.financial(),
+                request.comment(),
+                document,
+                reviewer
+        );
+        EvaluatorReview saved = evaluatorReviewRepository.save(review);
+        recalculateAverages(document);
+        return EvaluatorReviewIdResponse.of(saved.getId());
+    }
+
+    public EvaluatorReviewDetailResponse update(Long documentId, CustomUserDetails user, EvaluatorReviewUpdateRequest request) {
+        Document document = getDocument(documentId);
+        Member reviewer = getReviewer(user);
+        EvaluatorReview review = evaluatorReviewRepository.findByDocumentAndReviewer(document, reviewer)
+                .orElseThrow(() -> new UserExceptionHandler(ErrorCode.REVIEW_NOT_FOUND));
+
+        review.updateScores(
+                request.feasibility(),
+                request.differentiation(),
+                request.financial(),
+                request.comment()
+        );
+        evaluatorReviewRepository.save(review);
+        recalculateAverages(document);
+        return EvaluatorReviewDetailResponse.of(review);
+    }
+
+    @Transactional(readOnly = true)
+    public EvaluatorReviewDetailResponse getMyReview(Long documentId, CustomUserDetails user) {
+        Document document = getDocument(documentId);
+        Member reviewer = getReviewer(user);
+        EvaluatorReview review = evaluatorReviewRepository.findByDocumentAndReviewer(document, reviewer)
+                .orElseThrow(() -> new UserExceptionHandler(ErrorCode.REVIEW_NOT_FOUND));
+        return EvaluatorReviewDetailResponse.of(review);
+    }
+
+    @Transactional(readOnly = true)
+    public EvaluatorReviewListResponse list(Long documentId, CustomUserDetails user) {
+        Document document = getOwnedDocument(documentId, user);
+        List<EvaluatorReview> reviews = evaluatorReviewRepository.findAllByDocumentOrderByUpdatedAtDesc(document);
+        List<EvaluatorReviewListItemResponse> items = reviews.stream()
+                .map(EvaluatorReviewListItemResponse::of)
+                .toList();
+
+        double averageTotalScore = document.getReviewTotalAvg() == null ? 0.0 : document.getReviewTotalAvg();
+        int reviewCount = document.getReviewCount() == null ? 0 : document.getReviewCount();
+
+        return EvaluatorReviewListResponse.of(document.getId(), averageTotalScore, reviewCount, items);
+    }
+
+    public void delete(Long documentId, CustomUserDetails user) {
+        Document document = getDocument(documentId);
+        Member reviewer = getReviewer(user);
+        EvaluatorReview review = evaluatorReviewRepository.findByDocumentAndReviewer(document, reviewer)
+                .orElseThrow(() -> new UserExceptionHandler(ErrorCode.REVIEW_NOT_FOUND));
+
+        evaluatorReviewRepository.delete(review);
+        recalculateAverages(document);
+    }
+
+    private void recalculateAverages(Document document) {
+        List<EvaluatorReview> reviews = evaluatorReviewRepository.findAllByDocument(document);
+        if (reviews.isEmpty()) {
+            document.updateReviewSummary(0.0, 0.0, 0.0, 0.0, 0);
+            return;
+        }
+
+        double feasibilityAvg = reviews.stream().mapToInt(EvaluatorReview::getScoreFeasibility).average().orElse(0.0);
+        double differentiationAvg = reviews.stream().mapToInt(EvaluatorReview::getScoreDifferentiation).average().orElse(0.0);
+        double financialAvg = reviews.stream().mapToInt(EvaluatorReview::getScoreFinancial).average().orElse(0.0);
+        double totalAvg = reviews.stream().mapToDouble(EvaluatorReview::getScoreTotal).average().orElse(0.0);
+
+        document.updateReviewSummary(feasibilityAvg, differentiationAvg, financialAvg, totalAvg, reviews.size());
+    }
+
+    private Document getDocument(Long documentId) {
+        return documentRepository.findById(documentId)
+                .orElseThrow(() -> new UserExceptionHandler(ErrorCode.DOCUMENT_NOT_FOUND));
+    }
+
+    private Document getOwnedDocument(Long documentId, CustomUserDetails user) {
+        Document document = getDocument(documentId);
+        Member member = getReviewer(user);
+        if (document.getMember() == null || !document.getMember().getId().equals(member.getId())) {
+            throw new UserExceptionHandler(ErrorCode.DOCUMENT_FORBIDDEN);
+        }
+        return document;
+    }
+
+    private Member getReviewer(CustomUserDetails user) {
+        if (user == null || user.getMember() == null) {
+            throw new UserExceptionHandler(ErrorCode.MEMBER_NOT_FOUND);
+        }
+        return user.getMember();
+    }
+}

--- a/ssd-domain/src/test/java/or/hyu/ssd/domain/document/service/DocumentLogServiceTest.java
+++ b/ssd-domain/src/test/java/or/hyu/ssd/domain/document/service/DocumentLogServiceTest.java
@@ -1,0 +1,122 @@
+package or.hyu.ssd.domain.document.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import or.hyu.ssd.domain.document.controller.dto.DocumentLogResponse;
+import or.hyu.ssd.domain.document.entity.Document;
+import or.hyu.ssd.domain.document.entity.DocumentLog;
+import or.hyu.ssd.domain.document.repository.DocumentLogRepository;
+import or.hyu.ssd.domain.document.repository.DocumentRepository;
+import or.hyu.ssd.domain.member.entity.Member;
+import or.hyu.ssd.domain.member.entity.Role;
+import or.hyu.ssd.domain.member.service.CustomUserDetails;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DocumentLogServiceTest {
+
+    @Mock
+    private DocumentRepository documentRepository;
+    @Mock
+    private DocumentLogRepository documentLogRepository;
+
+    @InjectMocks
+    private DocumentLogService documentLogService;
+
+    @Test
+    @DisplayName("문서 기록은 날짜별로 그룹핑되어 최신 날짜 순으로 조회된다")
+    void list_groupsLogsByDate() {
+        Member member = member(1L, "owner@example.com");
+        Document document = document(10L, member);
+        CustomUserDetails user = new CustomUserDetails(member);
+
+        DocumentLog first = DocumentLog.builder()
+                .editorName("작성자")
+                .editorEmail("owner@example.com")
+                .document(document)
+                .build();
+        setCreatedAt(first, LocalDateTime.of(2026, 3, 17, 15, 10));
+
+        DocumentLog second = DocumentLog.builder()
+                .editorName("작성자")
+                .editorEmail("owner@example.com")
+                .document(document)
+                .build();
+        setCreatedAt(second, LocalDateTime.of(2026, 3, 17, 9, 5));
+
+        DocumentLog third = DocumentLog.builder()
+                .editorName("작성자")
+                .editorEmail("owner@example.com")
+                .document(document)
+                .build();
+        setCreatedAt(third, LocalDateTime.of(2026, 3, 16, 18, 0));
+
+        when(documentRepository.findById(10L)).thenReturn(Optional.of(document));
+        when(documentLogRepository.findAllByDocumentOrderByCreatedAtDesc(document)).thenReturn(List.of(first, second, third));
+
+        DocumentLogResponse response = documentLogService.list(10L, user);
+
+        assertThat(response.documentId()).isEqualTo(10L);
+        assertThat(response.records()).hasSize(2);
+        assertThat(response.records().get(0).savedDate()).isEqualTo("2026-03-17");
+        assertThat(response.records().get(0).logs()).hasSize(2);
+        assertThat(response.records().get(0).logs().get(0).savedTime()).isEqualTo("15:10");
+        assertThat(response.records().get(1).savedDate()).isEqualTo("2026-03-16");
+    }
+
+    @Test
+    @DisplayName("문서 기록은 문서 소유자가 아니면 조회할 수 없다")
+    void list_forbiddenWhenNotOwner() {
+        Member owner = member(1L, "owner@example.com");
+        Member other = member(2L, "other@example.com");
+        Document document = document(10L, owner);
+
+        when(documentRepository.findById(10L)).thenReturn(Optional.of(document));
+
+        assertThatThrownBy(() -> documentLogService.list(10L, new CustomUserDetails(other)))
+                .isInstanceOf(or.hyu.ssd.global.api.handler.UserExceptionHandler.class)
+                .hasMessage("해당 문서를 수정할 권한이 없습니다");
+    }
+
+    private void setCreatedAt(DocumentLog log, LocalDateTime createdAt) {
+        try {
+            java.lang.reflect.Field field = log.getClass().getSuperclass().getDeclaredField("createdAt");
+            field.setAccessible(true);
+            field.set(log, createdAt);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private Document document(Long id, Member member) {
+        return Document.builder()
+                .id(id)
+                .title("문서")
+                .content("본문")
+                .member(member)
+                .bookmark(false)
+                .build();
+    }
+
+    private Member member(Long id, String email) {
+        return Member.builder()
+                .id(id)
+                .name("사용자" + id)
+                .email(email)
+                .profileImageUrl("")
+                .profileImageKey(null)
+                .role(Role.ROLE_AUTHOR)
+                .build();
+    }
+}

--- a/ssd-domain/src/test/java/or/hyu/ssd/domain/document/service/DocumentServiceTest.java
+++ b/ssd-domain/src/test/java/or/hyu/ssd/domain/document/service/DocumentServiceTest.java
@@ -12,6 +12,7 @@ import or.hyu.ssd.domain.document.repository.DocumentLogRepository;
 import or.hyu.ssd.domain.document.repository.DocumentParagraphRepository;
 import or.hyu.ssd.domain.document.repository.DocumentRepository;
 import or.hyu.ssd.domain.document.repository.EvaluatorCheckListRepository;
+import or.hyu.ssd.domain.document.repository.EvaluatorReviewRepository;
 import or.hyu.ssd.domain.document.repository.FolderRepository;
 import or.hyu.ssd.domain.member.entity.Member;
 import or.hyu.ssd.domain.member.entity.Role;
@@ -52,6 +53,8 @@ class DocumentServiceTest {
     private DocumentCommentRepository documentCommentRepository;
     @Mock
     private DocumentLogRepository documentLogRepository;
+    @Mock
+    private EvaluatorReviewRepository evaluatorReviewRepository;
     @Mock
     private FolderRepository folderRepository;
     @Mock

--- a/ssd-domain/src/test/java/or/hyu/ssd/domain/document/service/EvaluatorReviewServiceTest.java
+++ b/ssd-domain/src/test/java/or/hyu/ssd/domain/document/service/EvaluatorReviewServiceTest.java
@@ -121,11 +121,11 @@ class EvaluatorReviewServiceTest {
     }
 
     @Test
-    @DisplayName("문서 리뷰 목록 조회는 문서 평균 점수와 각 평가자 총점을 반환한다")
+    @DisplayName("문서 리뷰 목록 조회는 문서 캐시값이 stale여도 실데이터 기준 평균을 반환한다")
     void list_returnsSummaryAndItems() {
         Member owner = member(1L, "owner@example.com");
         Document document = document(10L, owner);
-        document.updateReviewSummary(80.0, 70.0, 60.0, 70.0, 2);
+        document.updateReviewSummary(100.0, 100.0, 100.0, 100.0, 1);
         EvaluatorReview first = EvaluatorReview.of(80, 70, 60, "의견1", document, member(2L, "first@example.com"));
         EvaluatorReview second = EvaluatorReview.of(90, 80, 70, "의견2", document, member(3L, "second@example.com"));
 
@@ -135,7 +135,7 @@ class EvaluatorReviewServiceTest {
         EvaluatorReviewListResponse response = evaluatorReviewService.list(10L, new CustomUserDetails(owner));
 
         assertThat(response.documentId()).isEqualTo(10L);
-        assertThat(response.averageTotalScore()).isEqualTo(70.0);
+        assertThat(response.averageTotalScore()).isEqualTo(75.0);
         assertThat(response.reviewCount()).isEqualTo(2);
         assertThat(response.reviews()).hasSize(2);
         assertThat(response.reviews().get(0).reviewerName()).isEqualTo("사용자2");

--- a/ssd-domain/src/test/java/or/hyu/ssd/domain/document/service/EvaluatorReviewServiceTest.java
+++ b/ssd-domain/src/test/java/or/hyu/ssd/domain/document/service/EvaluatorReviewServiceTest.java
@@ -1,0 +1,164 @@
+package or.hyu.ssd.domain.document.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import or.hyu.ssd.domain.document.controller.dto.EvaluatorReviewCreateRequest;
+import or.hyu.ssd.domain.document.controller.dto.EvaluatorReviewDetailResponse;
+import or.hyu.ssd.domain.document.controller.dto.EvaluatorReviewListResponse;
+import or.hyu.ssd.domain.document.controller.dto.EvaluatorReviewUpdateRequest;
+import or.hyu.ssd.domain.document.entity.Document;
+import or.hyu.ssd.domain.document.entity.EvaluatorReview;
+import or.hyu.ssd.domain.document.repository.DocumentRepository;
+import or.hyu.ssd.domain.document.repository.EvaluatorReviewRepository;
+import or.hyu.ssd.domain.member.entity.Member;
+import or.hyu.ssd.domain.member.entity.Role;
+import or.hyu.ssd.domain.member.service.CustomUserDetails;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class EvaluatorReviewServiceTest {
+
+    @Mock
+    private EvaluatorReviewRepository evaluatorReviewRepository;
+    @Mock
+    private DocumentRepository documentRepository;
+
+    @InjectMocks
+    private EvaluatorReviewService evaluatorReviewService;
+
+    @Test
+    @DisplayName("이미 작성한 리뷰가 있으면 생성은 409 예외를 던진다")
+    void create_throwsConflictWhenReviewAlreadyExists() {
+        Member member = member(1L, "reviewer@example.com");
+        Document document = document(10L, member(2L, "owner@example.com"));
+        when(documentRepository.findById(10L)).thenReturn(Optional.of(document));
+        when(evaluatorReviewRepository.existsByDocumentAndReviewer(document, member)).thenReturn(true);
+
+        assertThatThrownBy(() -> evaluatorReviewService.create(
+                10L,
+                new CustomUserDetails(member),
+                new EvaluatorReviewCreateRequest(80, 90, 70, "좋은 사업입니다")
+        ))
+                .isInstanceOf(or.hyu.ssd.global.api.handler.UserExceptionHandler.class)
+                .hasMessage("이미 작성한 리뷰가 존재합니다");
+    }
+
+    @Test
+    @DisplayName("리뷰 수정은 기존 리뷰를 갱신하고 문서 평균을 재집계한다")
+    void update_recalculatesAverages() {
+        Member owner = member(1L, "owner@example.com");
+        Member reviewer = member(2L, "reviewer@example.com");
+        Document document = document(10L, owner);
+        EvaluatorReview review = EvaluatorReview.of(60, 70, 80, "초기 의견", document, reviewer);
+        EvaluatorReview other = EvaluatorReview.of(90, 90, 90, "다른 의견", document, member(3L, "third@example.com"));
+
+        when(documentRepository.findById(10L)).thenReturn(Optional.of(document));
+        when(evaluatorReviewRepository.findByDocumentAndReviewer(document, reviewer)).thenReturn(Optional.of(review));
+        when(evaluatorReviewRepository.findAllByDocument(document)).thenReturn(List.of(review, other));
+        when(evaluatorReviewRepository.save(any(EvaluatorReview.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        EvaluatorReviewDetailResponse response = evaluatorReviewService.update(
+                10L,
+                new CustomUserDetails(reviewer),
+                new EvaluatorReviewUpdateRequest(100, 80, 60, "수정 의견")
+        );
+
+        assertThat(response.feasibility()).isEqualTo(100);
+        assertThat(response.comment()).isEqualTo("수정 의견");
+        assertThat(document.getReviewFeasibilityAvg()).isEqualTo(95.0);
+        assertThat(document.getReviewDifferentiationAvg()).isEqualTo(85.0);
+        assertThat(document.getReviewFinancialAvg()).isEqualTo(75.0);
+        assertThat(document.getReviewTotalAvg()).isEqualTo(85.0);
+        assertThat(document.getReviewCount()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("리뷰 삭제 후 남은 리뷰가 없으면 평균값은 0으로 초기화된다")
+    void delete_resetsSummaryToZeroWhenNoReviewsRemain() {
+        Member owner = member(1L, "owner@example.com");
+        Member reviewer = member(2L, "reviewer@example.com");
+        Document document = document(10L, owner);
+        EvaluatorReview review = EvaluatorReview.of(60, 70, 80, "초기 의견", document, reviewer);
+
+        when(documentRepository.findById(10L)).thenReturn(Optional.of(document));
+        when(evaluatorReviewRepository.findByDocumentAndReviewer(document, reviewer)).thenReturn(Optional.of(review));
+        when(evaluatorReviewRepository.findAllByDocument(document)).thenReturn(List.of());
+
+        evaluatorReviewService.delete(10L, new CustomUserDetails(reviewer));
+
+        verify(evaluatorReviewRepository).delete(review);
+        assertThat(document.getReviewFeasibilityAvg()).isEqualTo(0.0);
+        assertThat(document.getReviewDifferentiationAvg()).isEqualTo(0.0);
+        assertThat(document.getReviewFinancialAvg()).isEqualTo(0.0);
+        assertThat(document.getReviewTotalAvg()).isEqualTo(0.0);
+        assertThat(document.getReviewCount()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("문서 리뷰 목록 조회는 문서 작성자만 가능하다")
+    void list_isOwnerOnly() {
+        Member owner = member(1L, "owner@example.com");
+        Member other = member(2L, "other@example.com");
+        Document document = document(10L, owner);
+
+        when(documentRepository.findById(10L)).thenReturn(Optional.of(document));
+
+        assertThatThrownBy(() -> evaluatorReviewService.list(10L, new CustomUserDetails(other)))
+                .isInstanceOf(or.hyu.ssd.global.api.handler.UserExceptionHandler.class)
+                .hasMessage("해당 문서를 수정할 권한이 없습니다");
+    }
+
+    @Test
+    @DisplayName("문서 리뷰 목록 조회는 문서 평균 점수와 각 평가자 총점을 반환한다")
+    void list_returnsSummaryAndItems() {
+        Member owner = member(1L, "owner@example.com");
+        Document document = document(10L, owner);
+        document.updateReviewSummary(80.0, 70.0, 60.0, 70.0, 2);
+        EvaluatorReview first = EvaluatorReview.of(80, 70, 60, "의견1", document, member(2L, "first@example.com"));
+        EvaluatorReview second = EvaluatorReview.of(90, 80, 70, "의견2", document, member(3L, "second@example.com"));
+
+        when(documentRepository.findById(10L)).thenReturn(Optional.of(document));
+        when(evaluatorReviewRepository.findAllByDocumentOrderByUpdatedAtDesc(document)).thenReturn(List.of(first, second));
+
+        EvaluatorReviewListResponse response = evaluatorReviewService.list(10L, new CustomUserDetails(owner));
+
+        assertThat(response.documentId()).isEqualTo(10L);
+        assertThat(response.averageTotalScore()).isEqualTo(70.0);
+        assertThat(response.reviewCount()).isEqualTo(2);
+        assertThat(response.reviews()).hasSize(2);
+        assertThat(response.reviews().get(0).reviewerName()).isEqualTo("사용자2");
+    }
+
+    private Document document(Long id, Member owner) {
+        return Document.builder()
+                .id(id)
+                .title("문서")
+                .content("본문")
+                .member(owner)
+                .bookmark(false)
+                .build();
+    }
+
+    private Member member(Long id, String email) {
+        return Member.builder()
+                .id(id)
+                .name("사용자" + id)
+                .email(email)
+                .profileImageUrl("")
+                .profileImageKey(null)
+                .role(Role.ROLE_AUTHOR)
+                .build();
+    }
+}

--- a/ssd-infra/src/main/java/or/hyu/ssd/infra/document/repository/DocumentLogRepositoryImpl.java
+++ b/ssd-infra/src/main/java/or/hyu/ssd/infra/document/repository/DocumentLogRepositoryImpl.java
@@ -20,8 +20,8 @@ public class DocumentLogRepositoryImpl implements DocumentLogRepository {
     }
 
     @Override
-    public List<DocumentLog> findAllByDocumentOrderByCreatedAtAsc(Document document) {
-        return documentLogJpaRepository.findAllByDocumentOrderByCreatedAtAsc(document);
+    public List<DocumentLog> findAllByDocumentOrderByCreatedAtDesc(Document document) {
+        return documentLogJpaRepository.findAllByDocumentOrderByCreatedAtDesc(document);
     }
 
     @Override

--- a/ssd-infra/src/main/java/or/hyu/ssd/infra/document/repository/EvaluatorReviewRepositoryImpl.java
+++ b/ssd-infra/src/main/java/or/hyu/ssd/infra/document/repository/EvaluatorReviewRepositoryImpl.java
@@ -27,6 +27,11 @@ public class EvaluatorReviewRepositoryImpl implements EvaluatorReviewRepository 
     }
 
     @Override
+    public List<EvaluatorReview> findAllByDocumentOrderByUpdatedAtDesc(Document document) {
+        return evaluatorReviewJpaRepository.findAllByDocumentOrderByUpdatedAtDesc(document);
+    }
+
+    @Override
     public boolean existsByDocumentAndReviewer(Document document, Member reviewer) {
         return evaluatorReviewJpaRepository.existsByDocumentAndReviewer(document, reviewer);
     }
@@ -34,5 +39,15 @@ public class EvaluatorReviewRepositoryImpl implements EvaluatorReviewRepository 
     @Override
     public EvaluatorReview save(EvaluatorReview review) {
         return evaluatorReviewJpaRepository.save(review);
+    }
+
+    @Override
+    public void delete(EvaluatorReview review) {
+        evaluatorReviewJpaRepository.delete(review);
+    }
+
+    @Override
+    public void deleteAllByDocument(Document document) {
+        evaluatorReviewJpaRepository.deleteAllByDocument(document);
     }
 }

--- a/ssd-infra/src/main/java/or/hyu/ssd/infra/document/repository/jpa/DocumentLogJpaRepository.java
+++ b/ssd-infra/src/main/java/or/hyu/ssd/infra/document/repository/jpa/DocumentLogJpaRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface DocumentLogJpaRepository extends JpaRepository<DocumentLog, Long> {
-    List<DocumentLog> findAllByDocumentOrderByCreatedAtAsc(Document document);
+    List<DocumentLog> findAllByDocumentOrderByCreatedAtDesc(Document document);
 
     void deleteAllByDocument(Document document);
 }

--- a/ssd-infra/src/main/java/or/hyu/ssd/infra/document/repository/jpa/EvaluatorReviewJpaRepository.java
+++ b/ssd-infra/src/main/java/or/hyu/ssd/infra/document/repository/jpa/EvaluatorReviewJpaRepository.java
@@ -13,5 +13,9 @@ public interface EvaluatorReviewJpaRepository extends JpaRepository<EvaluatorRev
 
     List<EvaluatorReview> findAllByDocument(Document document);
 
+    List<EvaluatorReview> findAllByDocumentOrderByUpdatedAtDesc(Document document);
+
     boolean existsByDocumentAndReviewer(Document document, Member reviewer);
+
+    void deleteAllByDocument(Document document);
 }


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #96
- close #97  

<br><br>

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

리뷰 API와 기록 API를 구현하였습니다.


<br><br>

## 🙏 Details

기록의 경우 생성 트리거가 문서 수정이기 때문에 따로 부가적인 API 없이 조회 API만 구현하였습니다.

현재 문서점수를 집계하는 트랜잭션과 CPU Bound가 매우 길고, 이에따라 점수를 집계할때의 동시성 이슈가 존재합니다. 이를 해결하기 위해 이슈를 생성하여 집중적으로 해결하도록 하겠습니다.

<!-- 이번 PR에서 구현한 내용 중 포인트가 되는 부분을 자세하게 적어주세요 -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 문서 변경 이력 조회 기능 추가: 문서의 모든 변경 내용을 날짜별로 그룹화하여 조회 가능
  * 평가자 리뷰 기능 추가: 평가자가 문서에 대해 리뷰를 작성, 수정, 조회, 삭제할 수 있는 기능 구현
  * 평가 점수 관리: 사업타당성, 사업차별성, 재무적정성을 0~100점으로 평가 및 관리

* **Tests**
  * 문서 로그 조회 기능 테스트 추가
  * 평가자 리뷰 CRUD 기능 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->