### PR TITLE
[FEATURE] AI 관련 mock API 구현

### DIFF
--- a/ssd-api/src/main/java/or/hyu/ssd/domain/document/controller/MockExternalAiController.java
+++ b/ssd-api/src/main/java/or/hyu/ssd/domain/document/controller/MockExternalAiController.java
@@ -1,0 +1,129 @@
+package or.hyu.ssd.domain.document.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
+import lombok.RequiredArgsConstructor;
+import or.hyu.ssd.domain.document.controller.dto.ExternalAiBatchResponse;
+import or.hyu.ssd.domain.document.controller.dto.ExternalAiChecklistResponse;
+import or.hyu.ssd.domain.document.controller.dto.ExternalAiDocumentCheckResponse;
+import or.hyu.ssd.domain.document.controller.dto.ExternalAiEvaluationCardResponse;
+import or.hyu.ssd.domain.document.controller.dto.ExternalAiKeywordResponse;
+import or.hyu.ssd.domain.document.controller.dto.ExternalAiSummaryResponse;
+import or.hyu.ssd.domain.document.controller.dto.ExternalDocumentIdRequest;
+import or.hyu.ssd.domain.document.service.MockExternalAiService;
+import or.hyu.ssd.domain.member.service.CustomUserDetails;
+import or.hyu.ssd.global.api.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+@Tag(name = "외부 AI Mock API", description = "클라이언트 연동용 하드코딩 응답 API")
+public class MockExternalAiController {
+
+    private final MockExternalAiService mockExternalAiService;
+
+    @PostMapping("/v1/mock/external-ai/evaluate")
+    @Operation(summary = "Mock 종합평가 반영", description = "외부 AI 평가 응답 스펙과 동일한 하드코딩 값을 반환합니다.")
+    public ResponseEntity<ApiResponse<ExternalAiEvaluationCardResponse>> evaluate(
+            @Valid @RequestBody ExternalDocumentIdRequest request,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        ExternalAiEvaluationCardResponse response = mockExternalAiService.evaluate(request);
+        return ResponseEntity.ok(ApiResponse.ok(response, "Mock 외부 종합평가가 조회되었습니다"));
+    }
+
+    @GetMapping("/v1/mock/external-ai/evaluate/{documentId}")
+    @Operation(summary = "Mock 종합평가 조회", description = "외부 AI 평가 조회 응답 스펙과 동일한 하드코딩 값을 반환합니다.")
+    public ResponseEntity<ApiResponse<ExternalAiEvaluationCardResponse>> getEvaluation(
+            @Parameter(description = "문서 ID", required = true)
+            @PathVariable @Positive(message = "문서 ID는 1 이상이어야 합니다") Long documentId,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        ExternalAiEvaluationCardResponse response = mockExternalAiService.getEvaluation(documentId);
+        return ResponseEntity.ok(ApiResponse.ok(response, "Mock 외부 종합평가가 조회되었습니다"));
+    }
+
+    @PostMapping("/v1/mock/external-ai/summarization/basic")
+    @Operation(summary = "Mock 요약 반영", description = "외부 AI 요약 응답 스펙과 동일한 하드코딩 값을 반환합니다.")
+    public ResponseEntity<ApiResponse<ExternalAiSummaryResponse>> summarizeBasic(
+            @Valid @RequestBody ExternalDocumentIdRequest request,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        ExternalAiSummaryResponse response = mockExternalAiService.summarizeBasic(request);
+        return ResponseEntity.ok(ApiResponse.ok(response, "Mock 외부 요약이 조회되었습니다"));
+    }
+
+    @GetMapping("/v1/mock/external-ai/summarization/basic/{documentId}")
+    @Operation(summary = "Mock 요약 조회", description = "외부 AI 요약 조회 응답 스펙과 동일한 하드코딩 값을 반환합니다.")
+    public ResponseEntity<ApiResponse<ExternalAiSummaryResponse>> getSummary(
+            @Parameter(description = "문서 ID", required = true)
+            @PathVariable @Positive(message = "문서 ID는 1 이상이어야 합니다") Long documentId,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        ExternalAiSummaryResponse response = mockExternalAiService.getSummary(documentId);
+        return ResponseEntity.ok(ApiResponse.ok(response, "Mock 외부 요약이 조회되었습니다"));
+    }
+
+    @PostMapping("/v1/mock/external-ai/summarization/keyword")
+    @Operation(summary = "Mock 키워드 반영", description = "외부 AI 키워드 응답 스펙과 동일한 하드코딩 값을 반환합니다.")
+    public ResponseEntity<ApiResponse<ExternalAiKeywordResponse>> summarizeKeyword(
+            @Valid @RequestBody ExternalDocumentIdRequest request,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        ExternalAiKeywordResponse response = mockExternalAiService.summarizeKeyword(request);
+        return ResponseEntity.ok(ApiResponse.ok(response, "Mock 외부 키워드가 조회되었습니다"));
+    }
+
+    @GetMapping("/v1/mock/external-ai/summarization/keyword/{documentId}")
+    @Operation(summary = "Mock 키워드 조회", description = "외부 AI 키워드 조회 응답 스펙과 동일한 하드코딩 값을 반환합니다.")
+    public ResponseEntity<ApiResponse<ExternalAiKeywordResponse>> getKeyword(
+            @Parameter(description = "문서 ID", required = true)
+            @PathVariable @Positive(message = "문서 ID는 1 이상이어야 합니다") Long documentId,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        ExternalAiKeywordResponse response = mockExternalAiService.getKeyword(documentId);
+        return ResponseEntity.ok(ApiResponse.ok(response, "Mock 외부 키워드가 조회되었습니다"));
+    }
+
+    @PostMapping("/v1/mock/external-ai/generate-all")
+    @Operation(summary = "Mock 외부 AI 일괄 반영", description = "평가, 요약, 키워드 응답을 한 번에 하드코딩 값으로 반환합니다.")
+    public ResponseEntity<ApiResponse<ExternalAiBatchResponse>> generateAll(
+            @Valid @RequestBody ExternalDocumentIdRequest request,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        ExternalAiBatchResponse response = mockExternalAiService.generateAll(request);
+        return ResponseEntity.ok(ApiResponse.ok(response, "Mock 외부 AI 결과가 일괄 조회되었습니다"));
+    }
+
+    @PostMapping("/v1/mock/external-ai/check/new-text")
+    @Operation(summary = "Mock 체크리스트 반영", description = "체크리스트 반영 응답 스펙과 동일한 하드코딩 값을 반환합니다.")
+    public ResponseEntity<ApiResponse<ExternalAiDocumentCheckResponse>> checkNewText(
+            @Valid @RequestBody ExternalDocumentIdRequest request,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        ExternalAiDocumentCheckResponse response = mockExternalAiService.checkNewText(request);
+        return ResponseEntity.ok(ApiResponse.ok(response, "Mock 외부 체크리스트가 조회되었습니다"));
+    }
+
+    @GetMapping("/v1/mock/external-ai/check/new-text/{documentId}")
+    @Operation(summary = "Mock 체크리스트 조회", description = "체크리스트 조회 응답 스펙과 동일한 하드코딩 값을 반환합니다.")
+    public ResponseEntity<ApiResponse<ExternalAiChecklistResponse>> getChecklist(
+            @Parameter(description = "문서 ID", required = true)
+            @PathVariable @Positive(message = "문서 ID는 1 이상이어야 합니다") Long documentId,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        ExternalAiChecklistResponse response = mockExternalAiService.getChecklist(documentId);
+        return ResponseEntity.ok(ApiResponse.ok(response, "Mock 외부 체크리스트가 조회되었습니다"));
+    }
+}

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/document/service/MockExternalAiService.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/document/service/MockExternalAiService.java
@@ -1,0 +1,135 @@
+package or.hyu.ssd.domain.document.service;
+
+import org.springframework.stereotype.Service;
+import or.hyu.ssd.domain.document.controller.dto.ExternalAiBatchResponse;
+import or.hyu.ssd.domain.document.controller.dto.ExternalAiChecklistResponse;
+import or.hyu.ssd.domain.document.controller.dto.ExternalAiDocumentCheckResponse;
+import or.hyu.ssd.domain.document.controller.dto.ExternalAiEvaluationCardResponse;
+import or.hyu.ssd.domain.document.controller.dto.ExternalAiEvaluationMetricResponse;
+import or.hyu.ssd.domain.document.controller.dto.ExternalAiKeywordResponse;
+import or.hyu.ssd.domain.document.controller.dto.ExternalAiSummaryResponse;
+import or.hyu.ssd.domain.document.controller.dto.ExternalDocumentIdRequest;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class MockExternalAiService {
+
+    public ExternalAiEvaluationCardResponse evaluate(ExternalDocumentIdRequest request) {
+        return buildEvaluation(parseDocumentId(request.docId()));
+    }
+
+    public ExternalAiEvaluationCardResponse getEvaluation(Long documentId) {
+        return buildEvaluation(documentId);
+    }
+
+    public ExternalAiSummaryResponse summarizeBasic(ExternalDocumentIdRequest request) {
+        return buildSummary(parseDocumentId(request.docId()));
+    }
+
+    public ExternalAiSummaryResponse getSummary(Long documentId) {
+        return buildSummary(documentId);
+    }
+
+    public ExternalAiKeywordResponse summarizeKeyword(ExternalDocumentIdRequest request) {
+        return buildKeyword(parseDocumentId(request.docId()));
+    }
+
+    public ExternalAiKeywordResponse getKeyword(Long documentId) {
+        return buildKeyword(documentId);
+    }
+
+    public ExternalAiDocumentCheckResponse checkNewText(ExternalDocumentIdRequest request) {
+        Long documentId = parseDocumentId(request.docId());
+        return ExternalAiDocumentCheckResponse.of(documentId, List.of(1, 3, 5), buildChecklist());
+    }
+
+    public ExternalAiChecklistResponse getChecklist(Long documentId) {
+        return ExternalAiChecklistResponse.of(documentId, buildChecklist());
+    }
+
+    public ExternalAiBatchResponse generateAll(ExternalDocumentIdRequest request) {
+        Long documentId = parseDocumentId(request.docId());
+        return ExternalAiBatchResponse.of(
+                documentId,
+                buildEvaluation(documentId),
+                buildSummary(documentId),
+                buildKeyword(documentId)
+        );
+    }
+
+    private ExternalAiEvaluationCardResponse buildEvaluation(Long documentId) {
+        return ExternalAiEvaluationCardResponse.of(
+                documentId,
+                63,
+                ExternalAiEvaluationMetricResponse.of(
+                        "문제 인식",
+                        70,
+                        "문제 정의는 비교적 명확하지만 시장 근거와 고객 세분화 데이터가 더 필요합니다."
+                ),
+                ExternalAiEvaluationMetricResponse.of(
+                        "실현 가능성",
+                        60,
+                        "솔루션 방향은 타당하지만 구현 범위와 실행 일정이 구체적으로 보강되어야 합니다."
+                ),
+                ExternalAiEvaluationMetricResponse.of(
+                        "성장 전략",
+                        55,
+                        "초기 확장 전략은 보이지만 채널별 성과 가설과 단계별 계획이 부족합니다."
+                ),
+                ExternalAiEvaluationMetricResponse.of(
+                        "Business Model",
+                        65,
+                        "수익 구조는 존재하지만 단가 근거와 반복 매출 구조 검증이 더 필요합니다."
+                ),
+                ExternalAiEvaluationMetricResponse.of(
+                        "팀 구성",
+                        65,
+                        "핵심 역할은 정의되어 있으나 도메인 전문성과 실행 인력 보강 계획이 필요합니다."
+                ),
+                buildChecklist()
+        );
+    }
+
+    private ExternalAiSummaryResponse buildSummary(Long documentId) {
+        return ExternalAiSummaryResponse.of(
+                documentId,
+                "공실 데이터를 통합해 예비 창업자의 비교 비용을 줄이는 사업계획서입니다.",
+                "공실 데이터 통합 서비스"
+        );
+    }
+
+    private ExternalAiKeywordResponse buildKeyword(Long documentId) {
+        return ExternalAiKeywordResponse.of(
+                documentId,
+                "공실, 상권분석, SaaS, 소상공인, 부동산데이터"
+        );
+    }
+
+    private Map<String, Boolean> buildChecklist() {
+        Map<String, Boolean> checklist = new LinkedHashMap<>();
+        checklist.put("differentiation_is_clear", true);
+        checklist.put("differentiation_is_realistic", false);
+        checklist.put("target_specific_advantage", true);
+        checklist.put("entry_barrier_exists", false);
+        checklist.put("problem_is_clear", true);
+        checklist.put("problem_is_real", true);
+        checklist.put("target_and_context_are_specific", true);
+        checklist.put("existing_solution_has_limits", true);
+        checklist.put("market_definition_is_correct", false);
+        checklist.put("market_size_is_realistic", false);
+        checklist.put("willingness_to_pay_is_clear", false);
+        checklist.put("revenue_model_is_clear", true);
+        checklist.put("problem_founder_fit", false);
+        checklist.put("experience_alignment", false);
+        checklist.put("team_structure_is_clear", true);
+        checklist.put("capability_gap_plan_exists", false);
+        return checklist;
+    }
+
+    private Long parseDocumentId(String rawDocId) {
+        return Long.parseLong(rawDocId);
+    }
+}

--- a/ssd-domain/src/test/java/or/hyu/ssd/domain/document/service/MockExternalAiServiceTest.java
+++ b/ssd-domain/src/test/java/or/hyu/ssd/domain/document/service/MockExternalAiServiceTest.java
@@ -1,0 +1,68 @@
+package or.hyu.ssd.domain.document.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import or.hyu.ssd.domain.document.controller.dto.ExternalAiBatchResponse;
+import or.hyu.ssd.domain.document.controller.dto.ExternalAiDocumentCheckResponse;
+import or.hyu.ssd.domain.document.controller.dto.ExternalAiEvaluationCardResponse;
+import or.hyu.ssd.domain.document.controller.dto.ExternalAiKeywordResponse;
+import or.hyu.ssd.domain.document.controller.dto.ExternalAiSummaryResponse;
+import or.hyu.ssd.domain.document.controller.dto.ExternalDocumentIdRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MockExternalAiServiceTest {
+
+    private final MockExternalAiService mockExternalAiService = new MockExternalAiService();
+
+    @Test
+    @DisplayName("evaluate()는 요청 docId를 유지한 하드코딩 평가 응답을 반환한다")
+    void evaluate_returnsMockResponse() {
+        ExternalAiEvaluationCardResponse response = mockExternalAiService.evaluate(new ExternalDocumentIdRequest("7"));
+
+        assertThat(response.documentId()).isEqualTo(7L);
+        assertThat(response.totalScore()).isEqualTo(63);
+        assertThat(response.problemRecognition().label()).isEqualTo("문제 인식");
+        assertThat(response.checkList()).containsEntry("problem_is_clear", true);
+    }
+
+    @Test
+    @DisplayName("summarizeBasic()는 요청 docId를 유지한 하드코딩 요약 응답을 반환한다")
+    void summarizeBasic_returnsMockResponse() {
+        ExternalAiSummaryResponse response = mockExternalAiService.summarizeBasic(new ExternalDocumentIdRequest("9"));
+
+        assertThat(response.documentId()).isEqualTo(9L);
+        assertThat(response.summary()).contains("공실 데이터");
+        assertThat(response.shortSummary()).isEqualTo("공실 데이터 통합 서비스");
+    }
+
+    @Test
+    @DisplayName("summarizeKeyword()는 요청 docId를 유지한 하드코딩 키워드 응답을 반환한다")
+    void summarizeKeyword_returnsMockResponse() {
+        ExternalAiKeywordResponse response = mockExternalAiService.summarizeKeyword(new ExternalDocumentIdRequest("11"));
+
+        assertThat(response.documentId()).isEqualTo(11L);
+        assertThat(response.keyword()).contains("공실");
+    }
+
+    @Test
+    @DisplayName("checkNewText()는 변경 블록과 체크리스트를 하드코딩 응답으로 반환한다")
+    void checkNewText_returnsMockResponse() {
+        ExternalAiDocumentCheckResponse response = mockExternalAiService.checkNewText(new ExternalDocumentIdRequest("13"));
+
+        assertThat(response.documentId()).isEqualTo(13L);
+        assertThat(response.changedBlockIds()).containsExactly(1, 3, 5);
+        assertThat(response.checkList()).containsEntry("team_structure_is_clear", true);
+    }
+
+    @Test
+    @DisplayName("generateAll()은 평가, 요약, 키워드를 한 번에 반환한다")
+    void generateAll_returnsMockBatchResponse() {
+        ExternalAiBatchResponse response = mockExternalAiService.generateAll(new ExternalDocumentIdRequest("15"));
+
+        assertThat(response.documentId()).isEqualTo(15L);
+        assertThat(response.evaluation().documentId()).isEqualTo(15L);
+        assertThat(response.summary().documentId()).isEqualTo(15L);
+        assertThat(response.keyword().documentId()).isEqualTo(15L);
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- closes #101

## 변경 요약
- 클라이언트 연동용 별도 mock 경로를 추가했습니다.
- 실제 외부 AI API와 동일한 응답 DTO 스펙을 사용하고, 값만 하드코딩해 반환합니다.
- POST API와 GET API를 모두 제공합니다.

## 핵심 구현 상세
- `/Users/jeonjaeyeon/Desktop/capstone/ssd/ssd-api/src/main/java/or/hyu/ssd/domain/document/controller/MockExternalAiController.java`
  - `/api/v1/mock/external-ai/*` 경로를 추가했습니다.
  - 평가, 요약, 키워드, 체크리스트, 일괄 생성 mock API를 제공합니다.
- `/Users/jeonjaeyeon/Desktop/capstone/ssd/ssd-domain/src/main/java/or/hyu/ssd/domain/document/service/MockExternalAiService.java`
  - 실제 DB/외부 AI 호출 없이 문서 ID만 반영한 하드코딩 응답을 생성합니다.
- `/Users/jeonjaeyeon/Desktop/capstone/ssd/ssd-domain/src/test/java/or/hyu/ssd/domain/document/service/MockExternalAiServiceTest.java`
  - 각 mock 응답이 기대 스펙과 문서 ID를 유지하는지 검증했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 모의 외부 AI 엔드포인트 추가 (평가, 요약, 키워드 추출, 일괄 생성, 체크리스트 작업 포함)
  * 문서 ID 기반의 평가 조회, 요약 조회, 키워드 조회, 체크리스트 조회 기능 추가

* **Tests**
  * 모의 AI 서비스 단위 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->