### PR TITLE
[FIX] 문서 수정 API에서 folderId 제거

### DIFF
--- a/ssd-api/src/main/java/or/hyu/ssd/domain/document/controller/DocumentController.java
+++ b/ssd-api/src/main/java/or/hyu/ssd/domain/document/controller/DocumentController.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import or.hyu.ssd.domain.document.service.DocumentService;
 import or.hyu.ssd.domain.document.controller.dto.CreateDocumentRequest;
 import or.hyu.ssd.domain.document.controller.dto.CreateDocumentResponse;
+import or.hyu.ssd.domain.document.controller.dto.UpdateDocumentRequest;
 import or.hyu.ssd.domain.document.controller.dto.UpdateDocumentResponse;
 import or.hyu.ssd.domain.member.service.CustomUserDetails;
 import or.hyu.ssd.global.api.ApiResponse;
@@ -95,10 +96,10 @@ public class DocumentController {
                         - role 허용값: "", "#", "##", "###", "####", "#####", "######"
                         - 기존 문단은 기존 blockId를 그대로 보내야 하며, 새 문단은 새 blockId를 사용합니다.
                         - 요청에서 빠진 blockId에 달린 주석은 함께 삭제됩니다.
-                      - folderId (number, optional): 폴더 ID (0이면 루트로 이동)
 
                     ### 제외 필드
-                    - summary, details, shortSummary, keywords, 외부 AI 평가값, checklist, bookmark는 이 API로 수정하지 않습니다.
+                    - folderId, summary, details, shortSummary, keywords, 외부 AI 평가값, checklist, bookmark는 이 API로 수정하지 않습니다.
+                    - 문서 이동은 별도 폴더 API로 처리합니다.
 
                     ### 응답
                     - 200 OK
@@ -114,7 +115,7 @@ public class DocumentController {
     public ResponseEntity<ApiResponse<UpdateDocumentResponse>> updateDocument(
             @Parameter(description = "수정할 문서 ID", example = "42")
             @PathVariable("id") @Positive(message = "문서 ID는 1 이상이어야 합니다") Long id,
-            @Valid @RequestBody CreateDocumentRequest request,
+            @Valid @RequestBody UpdateDocumentRequest request,
             @AuthenticationPrincipal CustomUserDetails user
     ) {
         UpdateDocumentResponse dto = documentService.updateDocument(id, user, request);

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/UpdateDocumentRequest.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/UpdateDocumentRequest.java
@@ -1,0 +1,13 @@
+package or.hyu.ssd.domain.document.controller.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+
+import java.util.List;
+
+public record UpdateDocumentRequest(
+        String title,
+        @NotBlank(message = "내용은 필수입니다")
+        String text,
+        List<@Valid CreateDocumentParagraphRequest> paragraphs
+) {}

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/document/service/DocumentService.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/document/service/DocumentService.java
@@ -6,6 +6,7 @@ import or.hyu.ssd.domain.document.controller.dto.CreateDocumentResponse;
 import or.hyu.ssd.domain.document.controller.dto.DocumentListItemResponse;
 import or.hyu.ssd.domain.document.controller.dto.DocumentParagraphDto;
 import or.hyu.ssd.domain.document.controller.dto.GetDocumentResponse;
+import or.hyu.ssd.domain.document.controller.dto.UpdateDocumentRequest;
 import or.hyu.ssd.domain.document.controller.dto.UpdateDocumentResponse;
 import or.hyu.ssd.domain.document.controller.dto.DocumentBookmarkResponse;
 import or.hyu.ssd.domain.document.entity.Document;
@@ -69,7 +70,7 @@ public class DocumentService {
         return CreateDocumentResponse.of(saved.getId());
     }
 
-    public UpdateDocumentResponse updateDocument(Long documentId, CustomUserDetails user, CreateDocumentRequest req) {
+    public UpdateDocumentResponse updateDocument(Long documentId, CustomUserDetails user, UpdateDocumentRequest req) {
         Document doc = getDocument(documentId);
 
         if (doc.getMember() == null || user == null || user.getMember() == null) {
@@ -82,10 +83,6 @@ public class DocumentService {
 
         String updatedTitle = resolveUpdatedTitle(doc.getTitle(), req.title());
         doc.updateIfPresent(updatedTitle, req.text(), null, null, null);
-        if (req.folderId() != null) {
-            Folder folder = resolveFolderOrNull(user, req.folderId());
-            doc.updateFolder(folder);
-        }
         int deletedBlockCount = 0;
         int createdBlockCount = 0;
         if (req.paragraphs() != null) {
@@ -227,7 +224,7 @@ public class DocumentService {
         return title != null ? title : currentTitle;
     }
 
-    private void validateUpdateRequest(CreateDocumentRequest req) {
+    private void validateUpdateRequest(UpdateDocumentRequest req) {
         if (req == null) {
             throw new DocumentException(ErrorCode.REQUEST_BODY_INVALID_VALUE, "수정 요청 본문이 비어 있습니다");
         }
@@ -237,7 +234,6 @@ public class DocumentService {
         if (req.text() == null || req.text().trim().isEmpty()) {
             throw new DocumentException(ErrorCode.REQUEST_BODY_INVALID_VALUE, "내용은 공백일 수 없습니다");
         }
-        validateFolderId(req.folderId());
     }
 
     private void validateFolderId(Long folderId) {

--- a/ssd-domain/src/test/java/or/hyu/ssd/domain/document/service/DocumentServiceTest.java
+++ b/ssd-domain/src/test/java/or/hyu/ssd/domain/document/service/DocumentServiceTest.java
@@ -3,6 +3,7 @@ package or.hyu.ssd.domain.document.service;
 import or.hyu.ssd.domain.document.controller.dto.CreateDocumentParagraphRequest;
 import or.hyu.ssd.domain.document.controller.dto.CreateDocumentRequest;
 import or.hyu.ssd.domain.document.controller.dto.CreateDocumentResponse;
+import or.hyu.ssd.domain.document.controller.dto.UpdateDocumentRequest;
 import or.hyu.ssd.domain.document.entity.Document;
 import or.hyu.ssd.domain.document.entity.DocumentParagraph;
 import or.hyu.ssd.domain.document.repository.CheckListRepository;
@@ -131,8 +132,8 @@ class DocumentServiceTest {
         assertThatThrownBy(() -> documentService.updateDocument(
                 42L,
                 user,
-                new CreateDocumentRequest(
-                        "   ", "본문", null, null
+                new UpdateDocumentRequest(
+                        "   ", "본문", null
                 )
         ))
                 .isInstanceOf(or.hyu.ssd.global.api.handler.DocumentException.class)
@@ -141,8 +142,8 @@ class DocumentServiceTest {
         assertThatThrownBy(() -> documentService.updateDocument(
                 42L,
                 user,
-                new CreateDocumentRequest(
-                        null, "   ", null, null
+                new UpdateDocumentRequest(
+                        null, "   ", null
                 )
         ))
                 .isInstanceOf(or.hyu.ssd.global.api.handler.DocumentException.class)
@@ -166,14 +167,13 @@ class DocumentServiceTest {
         documentService.updateDocument(
                 42L,
                 user,
-                new CreateDocumentRequest(
+                new UpdateDocumentRequest(
                         null,
                         "새 본문",
                         List.of(
                                 new CreateDocumentParagraphRequest("기존 문단 1 수정", "#", 1),
                                 new CreateDocumentParagraphRequest("새 문단", "", 3)
-                        ),
-                        0L
+                        )
                 )
         );
 
@@ -221,11 +221,10 @@ class DocumentServiceTest {
         assertThatThrownBy(() -> documentService.updateDocument(
                 42L,
                 user,
-                new CreateDocumentRequest(
+                new UpdateDocumentRequest(
                         null,
                         "본문",
-                        List.of(new CreateDocumentParagraphRequest("문단", "#", null)),
-                        0L
+                        List.of(new CreateDocumentParagraphRequest("문단", "#", null))
                 )
         ))
                 .isInstanceOf(or.hyu.ssd.global.api.handler.DocumentException.class)
@@ -234,14 +233,13 @@ class DocumentServiceTest {
         assertThatThrownBy(() -> documentService.updateDocument(
                 42L,
                 user,
-                new CreateDocumentRequest(
+                new UpdateDocumentRequest(
                         null,
                         "본문",
                         List.of(
                                 new CreateDocumentParagraphRequest("문단 1", "#", 1),
                                 new CreateDocumentParagraphRequest("문단 2", "##", 1)
-                        ),
-                        0L
+                        )
                 )
         ))
                 .isInstanceOf(or.hyu.ssd.global.api.handler.DocumentException.class)


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #109 


<br><br>

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

문서 수정 api request에 folderId를 제거하였습니다.

<br><br>

## 🙏 Details

<!-- 이번 PR에서 구현한 내용 중 포인트가 되는 부분을 자세하게 적어주세요 -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 문서 수정 기능을 개선했습니다. 이제 문서 콘텐츠(제목, 본문, 단락)의 업데이트와 폴더 이동이 명확히 분리되었으며, 폴더 간 이동은 별도의 폴더 관리 API를 통해 처리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->