### PR TITLE
[FEATURE] 리뷰 목록 응답에 상세 필드 추가

### DIFF
--- a/ssd-api/src/main/java/or/hyu/ssd/domain/document/controller/EvaluatorReviewController.java
+++ b/ssd-api/src/main/java/or/hyu/ssd/domain/document/controller/EvaluatorReviewController.java
@@ -107,8 +107,8 @@ public class EvaluatorReviewController {
             summary = "문서 리뷰 목록 조회",
             description = """
                     ### 개요
-                    - 문서 작성자가 해당 문서의 전체 리뷰 요약 목록을 조회합니다.
-                    - 모든 리뷰의 종합평점 평균과, 각 평가자의 이름/종합평점을 함께 반환합니다.
+                    - 문서 작성자가 해당 문서의 전체 리뷰 목록을 조회합니다.
+                    - 모든 리뷰의 종합평점 평균과 함께, 각 리뷰의 상세 정보(작성자, 이메일, 수정시각, 항목별 점수, 코멘트)를 반환합니다.
                     """
     )
     public ResponseEntity<ApiResponse<EvaluatorReviewListResponse>> list(

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/EvaluatorReviewListItemResponse.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/document/controller/dto/EvaluatorReviewListItemResponse.java
@@ -2,14 +2,30 @@ package or.hyu.ssd.domain.document.controller.dto;
 
 import or.hyu.ssd.domain.document.entity.EvaluatorReview;
 
+import java.time.LocalDateTime;
+
 public record EvaluatorReviewListItemResponse(
+        Long reviewId,
         String reviewerName,
-        double totalScore
+        String reviewerEmail,
+        LocalDateTime changedAt,
+        int feasibility,
+        int differentiation,
+        int financial,
+        double totalScore,
+        String comment
 ) {
     public static EvaluatorReviewListItemResponse of(EvaluatorReview review) {
         return new EvaluatorReviewListItemResponse(
+                review.getId(),
                 review.getReviewer() == null ? null : review.getReviewer().getName(),
-                review.getScoreTotal()
+                review.getReviewer() == null ? null : review.getReviewer().getEmail(),
+                review.getUpdatedAt(),
+                review.getScoreFeasibility(),
+                review.getScoreDifferentiation(),
+                review.getScoreFinancial(),
+                review.getScoreTotal(),
+                review.getComment()
         );
     }
 }

--- a/ssd-domain/src/test/java/or/hyu/ssd/domain/document/service/EvaluatorReviewServiceTest.java
+++ b/ssd-domain/src/test/java/or/hyu/ssd/domain/document/service/EvaluatorReviewServiceTest.java
@@ -138,7 +138,14 @@ class EvaluatorReviewServiceTest {
         assertThat(response.averageTotalScore()).isEqualTo(75.0);
         assertThat(response.reviewCount()).isEqualTo(2);
         assertThat(response.reviews()).hasSize(2);
+        assertThat(response.reviews().get(0).reviewId()).isNull();
         assertThat(response.reviews().get(0).reviewerName()).isEqualTo("사용자2");
+        assertThat(response.reviews().get(0).reviewerEmail()).isEqualTo("first@example.com");
+        assertThat(response.reviews().get(0).feasibility()).isEqualTo(80);
+        assertThat(response.reviews().get(0).differentiation()).isEqualTo(70);
+        assertThat(response.reviews().get(0).financial()).isEqualTo(60);
+        assertThat(response.reviews().get(0).totalScore()).isEqualTo(70.0);
+        assertThat(response.reviews().get(0).comment()).isEqualTo("의견1");
     }
 
     private Document document(Long id, Member owner) {


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #111 


<br><br>

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

리뷰 목록 응답이 업데이트 되었습니다.

```
{
  "code": "200",
  "msg": "리뷰 목록이 조회되었습니다",
  "data": {
    "documentId": 1,
    "averageTotalScore": 75.0,
    "reviewCount": 2,
    "reviews": [
      {
        "reviewId": 101,
        "reviewerName": "홍길동",
        "reviewerEmail": "hong@example.com",
        "changedAt": "2026-03-23T15:20:11",
        "feasibility": 80,
        "differentiation": 70,
        "financial": 75,
        "totalScore": 75.0,
        "comment": "시장 검증은 좋지만 수익 구조가 더 구체적이어야 합니다."
      },
      {
        "reviewId": 102,
        "reviewerName": "김영희",
        "reviewerEmail": "kim@example.com",
        "changedAt": "2026-03-23T16:02:44",
        "feasibility": 90,
        "differentiation": 85,
        "financial": 80,
        "totalScore": 85.0,
        "comment": "문제 정의와 차별점이 명확합니다."
      }
    ]
  }
}

```

예시는 위와 같습니다.


<br><br>

## 🙏 Details

<!-- 이번 PR에서 구현한 내용 중 포인트가 되는 부분을 자세하게 적어주세요 -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 리뷰 조회 API가 더 상세한 정보를 반환합니다. 검토자 이메일, 세부 평가 점수(실현성, 차별성, 재정성), 마지막 수정 시간, 검토 의견이 포함되도록 확대되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->