### PR TITLE
[FEATURE] 임시 로그인 로직 구현

### DIFF
--- a/ssd-api/src/main/java/or/hyu/ssd/domain/member/controller/OAuthController.java
+++ b/ssd-api/src/main/java/or/hyu/ssd/domain/member/controller/OAuthController.java
@@ -2,25 +2,21 @@ package or.hyu.ssd.domain.member.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import or.hyu.ssd.domain.member.service.CustomUserDetails;
 import or.hyu.ssd.domain.member.service.OAuthService;
 import or.hyu.ssd.global.api.ApiResponse;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.io.IOException;
-import jakarta.servlet.http.HttpServletRequest;
 
 @RestController
 @RequiredArgsConstructor
-@Slf4j
 @Tag(name = "소셜로그인 관련 API", description = "카카오 OAuth 시작/콜백 및 JWT 발급")
 public class OAuthController {
 
@@ -51,6 +47,28 @@ public class OAuthController {
          *   {base}/oauth/kakao/callback 콜백 URL을 계산해 카카오로 302 리다이렉트 합니다.
          */
         String redirectAddress = oAuthService.requestRedirect(request);
+        response.sendRedirect(redirectAddress);
+    }
+
+    @GetMapping("/oauth/kakao/login")
+    @Operation(
+            summary = "카카오 로그인 시작(최종 리다이렉트 포함)",
+            description = """
+                    ### 개요
+                    - 서버가 카카오 로그인과 JWT 발급까지 완료한 뒤, 최종 클라이언트 redirect 주소로 다시 리다이렉트합니다.
+                    - redirect 주소는 화이트리스트 origin 검증 후 state와 함께 저장됩니다.
+
+                    ### 요청
+                    - GET /oauth/kakao/login?redirect=https://client.example.com/redirect
+
+                    ### 응답
+                    - 302 Redirect: 카카오 인증 서버
+                    """
+    )
+    public void kakaoOAuthLoginStart(@RequestParam("redirect") String redirect,
+                                     HttpServletRequest request,
+                                     HttpServletResponse response) throws IOException {
+        String redirectAddress = oAuthService.requestRedirectWithClientRedirect(request, redirect);
         response.sendRedirect(redirectAddress);
     }
 
@@ -98,7 +116,7 @@ public class OAuthController {
                     - data: true/false
                     """
     )
-    @GetMapping("/oauth/kakao/callback")
+    @GetMapping(value = "/oauth/kakao/callback", params = "!state")
     public ResponseEntity<ApiResponse<Boolean>> kakaoLoginCallbackGet(
             @RequestParam("code") String accessCode,
             HttpServletRequest request,
@@ -106,6 +124,30 @@ public class OAuthController {
 
         Boolean result = oAuthService.kakaoLoginNoState(accessCode, request, response);
         return ResponseEntity.ok(ApiResponse.ok(result, "성공적으로 로그인이 완료되었습니다"));
+    }
+
+    @Operation(
+            summary = "카카오 로그인 콜백(최종 리다이렉트)",
+            description = """
+                    ### 개요
+                    - 카카오 인가코드를 서버가 받아 로그인과 JWT 발급을 완료한 뒤, state에 저장된 redirect 주소로 다시 리다이렉트합니다.
+
+                    ### 요청
+                    - GET /oauth/kakao/callback?code=...&state=...
+
+                    ### 응답
+                    - 302 Redirect: {redirect}#accessToken=...&isNewUser=...
+                    - 쿠키: refresh-token
+                    """
+    )
+    @GetMapping(value = "/oauth/kakao/callback", params = "state")
+    public void kakaoLoginCallbackRedirect(
+            @RequestParam("code") String accessCode,
+            @RequestParam("state") String state,
+            HttpServletRequest request,
+            HttpServletResponse response) {
+
+        oAuthService.kakaoLoginAndRedirect(accessCode, state, request, response);
     }
 
 

--- a/ssd-api/src/test/java/or/hyu/ssd/global/config/properties/WhiteListConfigTest.java
+++ b/ssd-api/src/test/java/or/hyu/ssd/global/config/properties/WhiteListConfigTest.java
@@ -13,4 +13,11 @@ class WhiteListConfigTest {
         assertThat(WhiteListConfig.actuatorWhitelist())
                 .contains("/actuator/prometheus", "/actuator/health", "/actuator/health/**");
     }
+
+    @Test
+    @DisplayName("oauthWhitelist()는 카카오 로그인 redirect 시작 엔드포인트를 포함한다")
+    void oauthWhitelist_containsKakaoRedirectLoginEndpoint() {
+        assertThat(WhiteListConfig.oauthWhitelist())
+                .contains("/oauth/kakao/login");
+    }
 }

--- a/ssd-core/src/main/java/or/hyu/ssd/global/config/properties/OAuthProperties.java
+++ b/ssd-core/src/main/java/or/hyu/ssd/global/config/properties/OAuthProperties.java
@@ -11,6 +11,7 @@ import java.util.List;
 /**
  * app.oauth.* 관련 설정값을 바인딩합니다.
  * - allowed-origins: 동적 redirect_uri 생성 시 허용할 Origin 화이트리스트
+ * - redirect-state-ttl-seconds: 로그인 redirect state 보관 시간(초)
  */
 @Getter
 @Setter
@@ -19,5 +20,7 @@ import java.util.List;
 public class OAuthProperties {
 
     private List<String> allowedOrigins = new ArrayList<>();
+
+    private long redirectStateTtlSeconds = 300L;
 }
 

--- a/ssd-core/src/main/java/or/hyu/ssd/global/config/properties/WhiteListConfig.java
+++ b/ssd-core/src/main/java/or/hyu/ssd/global/config/properties/WhiteListConfig.java
@@ -30,6 +30,7 @@ public class WhiteListConfig {
         return List.of(
                 "/oauth/kakao",
                 "/oauth/kakao/",
+                "/oauth/kakao/login",
                 "/oauth/kakao/callback",
                 "/oauth/kakao/server",
                 "/oauth/kakao/server/callback",

--- a/ssd-core/src/main/java/or/hyu/ssd/global/oauth/repository/OAuthRedirectStateRepository.java
+++ b/ssd-core/src/main/java/or/hyu/ssd/global/oauth/repository/OAuthRedirectStateRepository.java
@@ -1,0 +1,35 @@
+package or.hyu.ssd.global.oauth.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class OAuthRedirectStateRepository {
+
+    private static final String PREFIX = "oauth-redirect-state:";
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public void save(String state, String redirectUri, long ttlSeconds) {
+        redisTemplate.opsForValue().set(key(state), redirectUri, Duration.ofSeconds(ttlSeconds));
+    }
+
+    public Optional<String> consume(String state) {
+        String key = key(state);
+        String redirectUri = redisTemplate.opsForValue().get(key);
+        if (redirectUri == null) {
+            return Optional.empty();
+        }
+        redisTemplate.delete(key);
+        return Optional.of(redirectUri);
+    }
+
+    private String key(String state) {
+        return PREFIX + state;
+    }
+}

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/member/service/OAuthService.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/member/service/OAuthService.java
@@ -12,30 +12,34 @@ import or.hyu.ssd.domain.member.controller.dto.kakao.KaKaoUserInfoResponse;
 import or.hyu.ssd.domain.member.entity.Member;
 import or.hyu.ssd.domain.member.entity.Role;
 import or.hyu.ssd.domain.member.repository.MemberRepository;
-import or.hyu.ssd.global.jwt.repository.RefreshTokenRepository;
-import or.hyu.ssd.global.api.ErrorCode;
-import or.hyu.ssd.global.api.handler.UserExceptionHandler;
-import or.hyu.ssd.global.config.properties.CookieConfig;
-import or.hyu.ssd.global.config.properties.JWTConfig;
-import or.hyu.ssd.global.config.KaKaoConfig;
-import or.hyu.ssd.global.config.properties.OAuthProperties;
-import or.hyu.ssd.global.jwt.JWTUtil;
+import or.hyu.ssd.domain.member.service.support.KakaoLoginResult;
 import or.hyu.ssd.domain.member.service.support.KakaoProfileExtractor;
 import or.hyu.ssd.domain.member.service.support.KakaoProfileExtractor.NormalizedKakaoProfile;
+import or.hyu.ssd.global.api.ErrorCode;
+import or.hyu.ssd.global.api.handler.UserExceptionHandler;
+import or.hyu.ssd.global.config.KaKaoConfig;
+import or.hyu.ssd.global.config.properties.CookieConfig;
+import or.hyu.ssd.global.config.properties.OAuthProperties;
+import or.hyu.ssd.global.jwt.JWTUtil;
+import or.hyu.ssd.global.jwt.repository.RefreshTokenRepository;
+import or.hyu.ssd.global.oauth.repository.OAuthRedirectStateRepository;
+import or.hyu.ssd.global.config.properties.JWTConfig;
 import or.hyu.ssd.global.util.CookieUtil;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
+import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.UUID;
 
-
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class OAuthService {
+
+    private static final String DYNAMIC_CALLBACK_PATH = "/oauth/kakao/callback";
 
     private final KaKaoOAuthClient kaKaoOAuthClient;
     private final KaKaoUserInfoClient kaKaoUserInfoClient;
@@ -43,91 +47,85 @@ public class OAuthService {
     private final JWTUtil jwtUtil;
     private final JWTConfig jwtConfig;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final OAuthRedirectStateRepository oAuthRedirectStateRepository;
 
     private final KaKaoConfig kaKaoConfig;
     private final CookieConfig cookieConfig;
     private final OAuthProperties oAuthProperties;
-
-
 
     /**
      * 카카오 authorize URL 생성 (동적 콜백)
      * - Origin 기반 또는 요청의 스킴/호스트/포트로 "{base}/oauth/kakao/callback"을 계산합니다.
      * - 프론트 콜백 플로우에 사용합니다.
      */
-    public String requestRedirect(jakarta.servlet.http.HttpServletRequest request) {
-        String origin = request.getHeader("Origin");
-        String redirectBase;
-
-        if (StringUtils.hasText(origin)) {
-            // 브라우저가 보낸 Origin이 화이트리스트에 있는지 검증
-            List<String> allowed = oAuthProperties.getAllowedOrigins();
-            if (allowed != null && !allowed.isEmpty() && !allowed.contains(origin)) {
-                log.warn("허용되지 않은 Origin: {}", origin);
-                throw new UserExceptionHandler(ErrorCode.KAKAO_AUTH_CODE_INVALID);
-            }
-            redirectBase = origin;
-        } else {
-            // Origin 헤더가 없으면 현재 요청의 서버 기준으로 복원
-            String scheme = java.util.Objects.toString(request.getHeader("X-Forwarded-Proto"), request.getScheme());
-            String forwardedHost = request.getHeader("X-Forwarded-Host");
-            if (StringUtils.hasText(forwardedHost)) {
-                redirectBase = scheme + "://" + forwardedHost;
-            } else {
-                String host = request.getServerName();
-                int port = request.getServerPort();
-                boolean isDefault = ("http".equalsIgnoreCase(scheme) && port == 80) || ("https".equalsIgnoreCase(scheme) && port == 443);
-                redirectBase = scheme + "://" + host + (isDefault ? "" : ":" + port);
-            }
-        }
-
-        String redirectUri = redirectBase + "/oauth/kakao/callback";
-
-        String encodedRedirect = URLEncoder.encode(redirectUri, StandardCharsets.UTF_8);
-        String encodedScope = URLEncoder.encode(kaKaoConfig.getScope(), StandardCharsets.UTF_8);
-
-        return String.format(
-                "https://kauth.kakao.com/oauth/authorize?client_id=%s&redirect_uri=%s&response_type=code&scope=%s&prompt=consent",
-                kaKaoConfig.getClientId(), encodedRedirect, encodedScope
-        );
+    public String requestRedirect(HttpServletRequest request) {
+        String redirectUri = resolveDynamicCallbackUri(request);
+        return buildAuthorizeUrl(redirectUri, null);
     }
 
     /**
-     * 프론트에서 받은 code/state를 검증하고, state에 저장된 redirect_uri로 토큰 교환을 수행합니다.
-     * 이후 사용자 저장/조회 및 JWT 발급까지 처리합니다.
+     * 카카오 로그인 시작(최종 리다이렉트 포함)
+     * - redirect 파라미터를 검증한 뒤 짧은 TTL의 state와 매핑합니다.
+     * - 카카오 콜백은 기존 /oauth/kakao/callback 경로를 재사용합니다.
+     */
+    public String requestRedirectWithClientRedirect(HttpServletRequest request, String redirectUri) {
+        String validatedRedirectUri = validateClientRedirectUri(redirectUri);
+        String state = UUID.randomUUID().toString();
+        oAuthRedirectStateRepository.save(state, validatedRedirectUri, oAuthProperties.getRedirectStateTtlSeconds());
+        return buildAuthorizeUrl(resolveDynamicCallbackUri(request), state);
+    }
+
+    /**
+     * 프론트에서 받은 code를 기반으로 토큰 교환/회원 처리/JWT 발급을 수행합니다.
      */
     public Boolean kakaoLoginNoState(String accessCode, HttpServletRequest request, HttpServletResponse response) {
+        KakaoLoginResult loginResult = completeKakaoLogin(accessCode, resolveDynamicCallbackUri(request));
+        writeTokens(response, loginResult);
+        return loginResult.isNewUser();
+    }
 
-        Boolean isNewUser = false;
+    /**
+     * redirect 로그인 콜백
+     * - state에 저장된 최종 클라이언트 redirect 주소를 복원합니다.
+     * - 로그인 완료 후 refresh cookie를 설정하고 access token은 URL fragment로 전달합니다.
+     */
+    public void kakaoLoginAndRedirect(String accessCode,
+                                      String state,
+                                      HttpServletRequest request,
+                                      HttpServletResponse response) {
 
+        String redirectUri = oAuthRedirectStateRepository.consume(state)
+                .orElseThrow(() -> new UserExceptionHandler(ErrorCode.REQUEST_PARAMETER_INVALID, "'state' 파라미터가 올바르지 않습니다"));
+
+        KakaoLoginResult loginResult = completeKakaoLogin(accessCode, resolveDynamicCallbackUri(request));
+        writeTokens(response, loginResult);
+        response.setHeader("Location", buildRedirectLocation(redirectUri, loginResult));
+        response.setStatus(HttpServletResponse.SC_FOUND);
+    }
+
+    /**
+     * 항상 서버 콜백 방식 - 시작 단계 (yml redirect_uri 사용)
+     * - yml에 설정된 redirect_uri를 그대로 사용합니다.
+     */
+    public String requestRedirectServer(HttpServletRequest request) {
+        return buildAuthorizeUrl(kaKaoConfig.getRedirectUri(), null);
+    }
+
+    /**
+     * 항상 서버 콜백 방식 - 카카오로부터 서버 콜백을 받을 때 호출 (yml redirect_uri 사용)
+     * - 설정된 redirect_uri로 토큰 교환을 수행합니다.
+     */
+    public Boolean kakaoLoginServer(String accessCode, HttpServletRequest request, HttpServletResponse response) {
+        KakaoLoginResult loginResult = completeKakaoLogin(accessCode, kaKaoConfig.getRedirectUri());
+        writeTokens(response, loginResult);
+        return loginResult.isNewUser();
+    }
+
+    private KakaoLoginResult completeKakaoLogin(String accessCode, String redirectUri) {
         if (!StringUtils.hasText(accessCode)) {
             throw new UserExceptionHandler(ErrorCode.KAKAO_AUTH_CODE_INVALID);
         }
 
-        // 동적 콜백 redirect_uri를 재구성 (인가요청에서 사용한 값과 일치하도록)
-        String origin = request.getHeader("Origin");
-        String redirectBase;
-        if (StringUtils.hasText(origin)) {
-            List<String> allowed = oAuthProperties.getAllowedOrigins();
-            if (allowed != null && !allowed.isEmpty() && !allowed.contains(origin)) {
-                throw new UserExceptionHandler(ErrorCode.KAKAO_AUTH_CODE_INVALID);
-            }
-            redirectBase = origin;
-        } else {
-            String scheme = java.util.Objects.toString(request.getHeader("X-Forwarded-Proto"), request.getScheme());
-            String forwardedHost = request.getHeader("X-Forwarded-Host");
-            if (StringUtils.hasText(forwardedHost)) {
-                redirectBase = scheme + "://" + forwardedHost;
-            } else {
-                String host = request.getServerName();
-                int port = request.getServerPort();
-                boolean isDefault = ("http".equalsIgnoreCase(scheme) && port == 80) || ("https".equalsIgnoreCase(scheme) && port == 443);
-                redirectBase = scheme + "://" + host + (isDefault ? "" : ":" + port);
-            }
-        }
-        String redirectUri = redirectBase + "/oauth/kakao/callback";
-
-        // 액세스 토큰 발급
         KaKaoOAuthTokenDTO authorizationCode;
         try {
             log.info("액세스 토큰 발급을 시작합니다");
@@ -142,152 +140,150 @@ public class OAuthService {
             throw new UserExceptionHandler(ErrorCode.KAKAO_AUTH_CODE_INVALID);
         }
 
-        // 사용자 정보 조회
         KaKaoUserInfoResponse userInfo;
         try {
-            userInfo = kaKaoUserInfoClient.getUserInfo(
-                    "Bearer " + authorizationCode.getAccess_token());
+            userInfo = kaKaoUserInfoClient.getUserInfo("Bearer " + authorizationCode.getAccess_token());
         } catch (FeignException e) {
             throw new UserExceptionHandler(ErrorCode.KAKAO_ACCESSTOKEN_INVALID);
         }
 
-        // 캡슐화된 파서로 안전하게 추출
-        NormalizedKakaoProfile p = KakaoProfileExtractor.extract(userInfo);
-
-        if (!StringUtils.hasText(p.email())) {
+        NormalizedKakaoProfile profile = KakaoProfileExtractor.extract(userInfo);
+        if (!StringUtils.hasText(profile.email())) {
             log.warn("카카오 로그인 실패: 이메일 동의가 없어 회원 이메일을 확인할 수 없습니다");
             throw new UserExceptionHandler(ErrorCode.KAKAO_AUTH_CODE_INVALID);
         }
 
-        // 신규 회원 생성
-        Boolean userExist = userRepository.existsByEmail(p.email());
+        boolean isNewUser = createMemberIfAbsent(profile);
 
-        if (userExist == Boolean.FALSE) {
-
-            String profileImageKey = "kakao:" + (p.kakaoId() != null ? p.kakaoId() : java.util.UUID.randomUUID());
-
-            Member newMember = Member.join(p.nickname(), p.email(), p.profileImageUrl(), profileImageKey, Role.ROLE_AUTHOR);
-
-            userRepository.save(newMember);
-
-            isNewUser = true;
-        }
-
-        // 그리고 회원 정보를 기반으로 액세스토큰을 발급하여 헤더에 넣습니다
-        Member byEmail = userRepository.findByEmail(p.email())
+        Member member = userRepository.findByEmail(profile.email())
                 .orElseThrow(() -> new UserExceptionHandler(ErrorCode.MEMBER_NOT_FOUND));
 
-        String access = jwtUtil.createJwt("access", byEmail.getId(), byEmail.getRole().toString(), jwtConfig.getAccessTokenValidityInSeconds());
-        String refresh = jwtUtil.createJwt("refresh", byEmail.getId(), byEmail.getRole().toString(), jwtConfig.getRefreshTokenValidityInSeconds());
+        String access = jwtUtil.createJwt("access", member.getId(), member.getRole().toString(), jwtConfig.getAccessTokenValidityInSeconds());
+        String refresh = jwtUtil.createJwt("refresh", member.getId(), member.getRole().toString(), jwtConfig.getRefreshTokenValidityInSeconds());
 
-        refreshTokenRepository.saveRefreshToken(byEmail.getId(), refresh, jwtConfig.getRefreshTokenValidityInSeconds());
+        refreshTokenRepository.saveRefreshToken(member.getId(), refresh, jwtConfig.getRefreshTokenValidityInSeconds());
 
-        response.setHeader("access-token", access);
+        return new KakaoLoginResult(access, refresh, isNewUser);
+    }
 
+    private boolean createMemberIfAbsent(NormalizedKakaoProfile profile) {
+        Boolean userExist = userRepository.existsByEmail(profile.email());
+        if (Boolean.TRUE.equals(userExist)) {
+            return false;
+        }
+
+        String profileImageKey = "kakao:" + (profile.kakaoId() != null ? profile.kakaoId() : UUID.randomUUID());
+        Member newMember = Member.join(profile.nickname(), profile.email(), profile.profileImageUrl(), profileImageKey, Role.ROLE_AUTHOR);
+        userRepository.save(newMember);
+        return true;
+    }
+
+    private void writeTokens(HttpServletResponse response, KakaoLoginResult loginResult) {
+        response.setHeader("access-token", loginResult.accessToken());
         CookieUtil.addSameSiteCookie(
                 response,
                 "refresh-token",
-                refresh,
+                loginResult.refreshToken(),
                 jwtConfig.getRefreshTokenValidityInSeconds().intValue(),
                 cookieConfig.getDomain(),
                 cookieConfig.isSecure(),
                 cookieConfig.getSameSite()
         );
-
-        return isNewUser;
     }
 
+    private String resolveDynamicCallbackUri(HttpServletRequest request) {
+        return resolveRequestBase(request) + DYNAMIC_CALLBACK_PATH;
+    }
 
+    private String resolveRequestBase(HttpServletRequest request) {
+        String origin = request.getHeader("Origin");
+        if (StringUtils.hasText(origin)) {
+            if (!isAllowedOrigin(origin)) {
+                log.warn("허용되지 않은 Origin: {}", origin);
+                throw new UserExceptionHandler(ErrorCode.KAKAO_AUTH_CODE_INVALID);
+            }
+            return origin;
+        }
 
+        String scheme = String.valueOf(request.getHeader("X-Forwarded-Proto"));
+        if (!StringUtils.hasText(scheme) || "null".equalsIgnoreCase(scheme)) {
+            scheme = request.getScheme();
+        }
 
-    /**
-     * 항상 서버 콜백 방식 - 시작 단계 (yml redirect_uri 사용)
-     * - yml에 설정된 redirect_uri를 그대로 사용합니다.
-     */
-    public String requestRedirectServer(HttpServletRequest request) {
-        String redirectUri = kaKaoConfig.getRedirectUri();
+        String forwardedHost = request.getHeader("X-Forwarded-Host");
+        if (StringUtils.hasText(forwardedHost)) {
+            return scheme + "://" + forwardedHost;
+        }
 
+        String host = request.getServerName();
+        int port = request.getServerPort();
+        boolean isDefaultPort = ("http".equalsIgnoreCase(scheme) && port == 80)
+                || ("https".equalsIgnoreCase(scheme) && port == 443);
+        return scheme + "://" + host + (isDefaultPort ? "" : ":" + port);
+    }
+
+    private boolean isAllowedOrigin(String origin) {
+        List<String> allowed = oAuthProperties.getAllowedOrigins();
+        return allowed == null || allowed.isEmpty() || allowed.contains(origin);
+    }
+
+    private String validateClientRedirectUri(String redirectUri) {
+        if (!StringUtils.hasText(redirectUri)) {
+            throw new UserExceptionHandler(ErrorCode.REQUEST_PARAMETER_INVALID, "'redirect' 파라미터가 필요합니다");
+        }
+
+        URI uri;
+        try {
+            uri = URI.create(redirectUri);
+        } catch (IllegalArgumentException e) {
+            throw new UserExceptionHandler(ErrorCode.REQUEST_PARAMETER_INVALID, "'redirect' 파라미터 형식이 올바르지 않습니다");
+        }
+
+        String scheme = uri.getScheme();
+        if (!"http".equalsIgnoreCase(scheme) && !"https".equalsIgnoreCase(scheme)) {
+            throw new UserExceptionHandler(ErrorCode.REQUEST_PARAMETER_INVALID, "'redirect' 파라미터는 http 또는 https만 허용됩니다");
+        }
+        if (!StringUtils.hasText(uri.getHost())) {
+            throw new UserExceptionHandler(ErrorCode.REQUEST_PARAMETER_INVALID, "'redirect' 파라미터 형식이 올바르지 않습니다");
+        }
+
+        String origin = normalizeOrigin(uri);
+        if (!isAllowedOrigin(origin)) {
+            throw new UserExceptionHandler(ErrorCode.REQUEST_PARAMETER_INVALID, "'redirect' 파라미터 origin이 허용되지 않습니다");
+        }
+        return redirectUri;
+    }
+
+    private String normalizeOrigin(URI uri) {
+        String scheme = uri.getScheme().toLowerCase();
+        int port = uri.getPort();
+        boolean isDefaultPort = port == -1
+                || ("http".equalsIgnoreCase(scheme) && port == 80)
+                || ("https".equalsIgnoreCase(scheme) && port == 443);
+        return scheme + "://" + uri.getHost() + (isDefaultPort ? "" : ":" + port);
+    }
+
+    private String buildAuthorizeUrl(String redirectUri, String state) {
         String encodedRedirect = URLEncoder.encode(redirectUri, StandardCharsets.UTF_8);
         String encodedScope = URLEncoder.encode(kaKaoConfig.getScope(), StandardCharsets.UTF_8);
 
-        return String.format(
+        String url = String.format(
                 "https://kauth.kakao.com/oauth/authorize?client_id=%s&redirect_uri=%s&response_type=code&scope=%s&prompt=consent",
                 kaKaoConfig.getClientId(), encodedRedirect, encodedScope
         );
+        if (StringUtils.hasText(state)) {
+            url += "&state=" + URLEncoder.encode(state, StandardCharsets.UTF_8);
+        }
+        return url;
     }
 
-    /**
-     * 항상 서버 콜백 방식 - 카카오로부터 서버 콜백을 받을 때 호출 (yml redirect_uri 사용)
-     * - 설정된 redirect_uri로 토큰 교환을 수행합니다.
-     */
-    public Boolean kakaoLoginServer(String accessCode, HttpServletRequest request, HttpServletResponse response) {
-        Boolean isNewUser = false;
+    private String buildRedirectLocation(String redirectUri, KakaoLoginResult loginResult) {
+        String fragment = "accessToken=" + URLEncoder.encode(loginResult.accessToken(), StandardCharsets.UTF_8)
+                + "&isNewUser=" + loginResult.isNewUser();
 
-        if (!StringUtils.hasText(accessCode)) {
-            throw new UserExceptionHandler(ErrorCode.KAKAO_AUTH_CODE_INVALID);
+        if (redirectUri.contains("#")) {
+            return redirectUri + "&" + fragment;
         }
-
-        String redirectUri = kaKaoConfig.getRedirectUri();
-
-        KaKaoOAuthTokenDTO authorizationCode;
-        try {
-            log.info("액세스 토큰 발급을 시작합니다(서버 콜백)");
-            authorizationCode = kaKaoOAuthClient.getToken(
-                    "authorization_code",
-                    kaKaoConfig.getClientId(),
-                    redirectUri,
-                    accessCode
-            );
-        } catch (FeignException e) {
-            log.info(e.getMessage());
-            throw new UserExceptionHandler(ErrorCode.KAKAO_AUTH_CODE_INVALID);
-        }
-
-        KaKaoUserInfoResponse userInfo;
-        try {
-            userInfo = kaKaoUserInfoClient.getUserInfo(
-                    "Bearer " + authorizationCode.getAccess_token());
-        } catch (FeignException e) {
-            throw new UserExceptionHandler(ErrorCode.KAKAO_ACCESSTOKEN_INVALID);
-        }
-
-        // 캡슐화된 파서로 안전하게 추출
-        NormalizedKakaoProfile extractedUserInfo = KakaoProfileExtractor.extract(userInfo);
-
-        if (!StringUtils.hasText(extractedUserInfo.email())) {
-            log.warn("카카오 로그인 실패: 이메일 동의가 없어 회원 이메일을 확인할 수 없습니다");
-            throw new UserExceptionHandler(ErrorCode.KAKAO_AUTH_CODE_INVALID);
-        }
-
-        Boolean userExist = userRepository.existsByEmail(extractedUserInfo.email());
-        if (userExist == Boolean.FALSE) {
-            String profileImageKey = "kakao:" + (extractedUserInfo.kakaoId() != null ? extractedUserInfo.kakaoId() : java.util.UUID.randomUUID());
-
-            Member newMember = Member.join(extractedUserInfo.nickname(), extractedUserInfo.email(), extractedUserInfo.profileImageUrl(), profileImageKey, Role.ROLE_AUTHOR);
-
-            userRepository.save(newMember);
-            isNewUser = true;
-        }
-
-        Member byEmail = userRepository.findByEmail(extractedUserInfo.email())
-                .orElseThrow(() -> new UserExceptionHandler(ErrorCode.MEMBER_NOT_FOUND));
-
-        String access = jwtUtil.createJwt("access", byEmail.getId(), byEmail.getRole().toString(), jwtConfig.getAccessTokenValidityInSeconds());
-        String refresh = jwtUtil.createJwt("refresh", byEmail.getId(), byEmail.getRole().toString(), jwtConfig.getRefreshTokenValidityInSeconds());
-
-        refreshTokenRepository.saveRefreshToken(byEmail.getId(), refresh, jwtConfig.getRefreshTokenValidityInSeconds());
-
-        response.setHeader("access-token", access);
-        CookieUtil.addSameSiteCookie(
-                response,
-                "refresh-token",
-                refresh,
-                jwtConfig.getRefreshTokenValidityInSeconds().intValue(),
-                cookieConfig.getDomain(),
-                cookieConfig.isSecure(),
-                cookieConfig.getSameSite()
-        );
-
-        return isNewUser;
+        return redirectUri + "#" + fragment;
     }
 }

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/member/service/support/KakaoLoginResult.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/member/service/support/KakaoLoginResult.java
@@ -1,0 +1,8 @@
+package or.hyu.ssd.domain.member.service.support;
+
+public record KakaoLoginResult(
+        String accessToken,
+        String refreshToken,
+        boolean isNewUser
+) {
+}

--- a/ssd-domain/src/test/java/or/hyu/ssd/domain/member/service/OAuthServiceTest.java
+++ b/ssd-domain/src/test/java/or/hyu/ssd/domain/member/service/OAuthServiceTest.java
@@ -1,0 +1,204 @@
+package or.hyu.ssd.domain.member.service;
+
+import jakarta.servlet.http.HttpServletResponse;
+import or.hyu.ssd.domain.member.client.KaKaoOAuthClient;
+import or.hyu.ssd.domain.member.client.KaKaoUserInfoClient;
+import or.hyu.ssd.domain.member.controller.dto.kakao.KaKaoOAuthTokenDTO;
+import or.hyu.ssd.domain.member.controller.dto.kakao.KaKaoUserInfoResponse;
+import or.hyu.ssd.domain.member.entity.Member;
+import or.hyu.ssd.domain.member.entity.Role;
+import or.hyu.ssd.domain.member.repository.MemberRepository;
+import or.hyu.ssd.global.api.handler.UserExceptionHandler;
+import or.hyu.ssd.global.config.KaKaoConfig;
+import or.hyu.ssd.global.config.properties.CookieConfig;
+import or.hyu.ssd.global.config.properties.JWTConfig;
+import or.hyu.ssd.global.config.properties.OAuthProperties;
+import or.hyu.ssd.global.jwt.JWTUtil;
+import or.hyu.ssd.global.jwt.repository.RefreshTokenRepository;
+import or.hyu.ssd.global.oauth.repository.OAuthRedirectStateRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class OAuthServiceTest {
+
+    @Mock
+    private KaKaoOAuthClient kaKaoOAuthClient;
+    @Mock
+    private KaKaoUserInfoClient kaKaoUserInfoClient;
+    @Mock
+    private MemberRepository userRepository;
+    @Mock
+    private JWTUtil jwtUtil;
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+    @Mock
+    private OAuthRedirectStateRepository oAuthRedirectStateRepository;
+
+    private JWTConfig jwtConfig;
+    private KaKaoConfig kaKaoConfig;
+    private CookieConfig cookieConfig;
+    private OAuthProperties oAuthProperties;
+
+    private OAuthService oAuthService;
+
+    @BeforeEach
+    void setUp() {
+        jwtConfig = new JWTConfig();
+        jwtConfig.setAccessTokenValidityInSeconds(3600L);
+        jwtConfig.setRefreshTokenValidityInSeconds(2592000L);
+
+        kaKaoConfig = new KaKaoConfig();
+        ReflectionTestUtils.setField(kaKaoConfig, "clientId", "kakao-client-id");
+        ReflectionTestUtils.setField(kaKaoConfig, "scope", "profile_nickname,account_email");
+        ReflectionTestUtils.setField(kaKaoConfig, "redirectUri", "https://api.example.com/oauth/kakao/server/callback");
+
+        cookieConfig = new CookieConfig();
+        ReflectionTestUtils.setField(cookieConfig, "domain", "example.com");
+        ReflectionTestUtils.setField(cookieConfig, "secure", true);
+        ReflectionTestUtils.setField(cookieConfig, "sameSite", "None");
+
+        oAuthProperties = new OAuthProperties();
+        oAuthProperties.setAllowedOrigins(List.of(
+                "https://client.example.com",
+                "https://dev-api.simsaimdang.shop"
+        ));
+        oAuthProperties.setRedirectStateTtlSeconds(300L);
+
+        oAuthService = new OAuthService(
+                kaKaoOAuthClient,
+                kaKaoUserInfoClient,
+                userRepository,
+                jwtUtil,
+                jwtConfig,
+                refreshTokenRepository,
+                oAuthRedirectStateRepository,
+                kaKaoConfig,
+                cookieConfig,
+                oAuthProperties
+        );
+    }
+
+    @Test
+    @DisplayName("requestRedirectWithClientRedirect()는 허용된 redirect를 state와 저장하고 카카오 authorize URL을 반환한다")
+    void requestRedirectWithClientRedirect_savesStateAndBuildsAuthorizeUrl() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setScheme("https");
+        request.setServerName("dev-api.simsaimdang.shop");
+        request.setServerPort(443);
+
+        String authorizeUrl = oAuthService.requestRedirectWithClientRedirect(request, "https://client.example.com/redirect");
+
+        ArgumentCaptor<String> stateCaptor = ArgumentCaptor.forClass(String.class);
+        verify(oAuthRedirectStateRepository).save(stateCaptor.capture(), eq("https://client.example.com/redirect"), eq(300L));
+
+        assertThat(authorizeUrl)
+                .contains("https://kauth.kakao.com/oauth/authorize")
+                .contains("client_id=kakao-client-id")
+                .contains("redirect_uri=https%3A%2F%2Fdev-api.simsaimdang.shop%2Foauth%2Fkakao%2Fcallback")
+                .contains("state=" + stateCaptor.getValue());
+    }
+
+    @Test
+    @DisplayName("requestRedirectWithClientRedirect()는 허용되지 않은 redirect origin을 거부한다")
+    void requestRedirectWithClientRedirect_rejectsDisallowedRedirectOrigin() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setScheme("https");
+        request.setServerName("dev-api.simsaimdang.shop");
+        request.setServerPort(443);
+
+        assertThatThrownBy(() -> oAuthService.requestRedirectWithClientRedirect(request, "https://evil.example.com/redirect"))
+                .isInstanceOf(UserExceptionHandler.class)
+                .hasMessage("'redirect' 파라미터 origin이 허용되지 않습니다");
+    }
+
+    @Test
+    @DisplayName("kakaoLoginAndRedirect()는 토큰을 발급하고 최종 redirect 주소의 fragment로 access token을 전달한다")
+    void kakaoLoginAndRedirect_setsCookieAndRedirectsToClient() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setScheme("https");
+        request.setServerName("dev-api.simsaimdang.shop");
+        request.setServerPort(443);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        when(oAuthRedirectStateRepository.consume("state-1"))
+                .thenReturn(Optional.of("https://client.example.com/redirect"));
+        when(kaKaoOAuthClient.getToken(
+                eq("authorization_code"),
+                eq("kakao-client-id"),
+                eq("https://dev-api.simsaimdang.shop/oauth/kakao/callback"),
+                eq("auth-code")
+        )).thenReturn(kakaoToken("kakao-access-token"));
+        when(kaKaoUserInfoClient.getUserInfo("Bearer kakao-access-token"))
+                .thenReturn(kakaoUserInfo("tester@example.com", "테스터"));
+        when(userRepository.existsByEmail("tester@example.com")).thenReturn(true);
+        when(userRepository.findByEmail("tester@example.com")).thenReturn(Optional.of(member(1L)));
+        when(jwtUtil.createJwt(eq("access"), eq(1L), eq(Role.ROLE_AUTHOR.toString()), anyLong())).thenReturn("access-jwt");
+        when(jwtUtil.createJwt(eq("refresh"), eq(1L), eq(Role.ROLE_AUTHOR.toString()), anyLong())).thenReturn("refresh-jwt");
+
+        oAuthService.kakaoLoginAndRedirect("auth-code", "state-1", request, response);
+
+        assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_FOUND);
+        assertThat(response.getHeader("access-token")).isEqualTo("access-jwt");
+        assertThat(response.getHeader("Location"))
+                .isEqualTo("https://client.example.com/redirect#accessToken=access-jwt&isNewUser=false");
+        assertThat(response.getHeader("Set-Cookie"))
+                .contains("refresh-token=refresh-jwt")
+                .contains("Domain=example.com")
+                .contains("SameSite=None")
+                .contains("Secure")
+                .contains("HttpOnly");
+
+        verify(refreshTokenRepository).saveRefreshToken(1L, "refresh-jwt", 2592000L);
+    }
+
+    private KaKaoOAuthTokenDTO kakaoToken(String accessToken) {
+        KaKaoOAuthTokenDTO dto = new KaKaoOAuthTokenDTO();
+        dto.setAccess_token(accessToken);
+        return dto;
+    }
+
+    private KaKaoUserInfoResponse kakaoUserInfo(String email, String nickname) {
+        KaKaoUserInfoResponse response = new KaKaoUserInfoResponse();
+        response.setId(77L);
+
+        KaKaoUserInfoResponse.KakaoAccount.Profile profile = new KaKaoUserInfoResponse.KakaoAccount.Profile();
+        profile.setNickname(nickname);
+
+        KaKaoUserInfoResponse.KakaoAccount account = new KaKaoUserInfoResponse.KakaoAccount();
+        account.setEmail(email);
+        account.setProfile(profile);
+        response.setKakaoAccount(account);
+
+        return response;
+    }
+
+    private Member member(Long id) {
+        return Member.builder()
+                .id(id)
+                .name("테스터")
+                .email("tester@example.com")
+                .profileImageUrl("")
+                .profileImageKey("kakao:77")
+                .role(Role.ROLE_AUTHOR)
+                .build();
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #


<br><br>

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

```
클라이언트가 GET /oauth/kakao/login?redirect=https://client.../redirect 호출
서버가 redirect origin 검증 후 state를 Redis에 저장
카카오 authorize로 리다이렉트
카카오가 기존 /oauth/kakao/callback으로 code/state 전달
서버가 로그인/JWT 발급 완료
refresh token은 쿠키로 설정
access token은 최종 redirect URL fragment로 전달
예: https://client.../redirect#accessToken=...&isNewUser=false
```


<br><br>

## 🙏 Details

<!-- 이번 PR에서 구현한 내용 중 포인트가 되는 부분을 자세하게 적어주세요 -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * OAuth Kakao 로그인 시작을 위한 새로운 엔드포인트 추가
  * 클라이언트 리다이렉트 URL을 지원하는 OAuth 콜백 흐름 개선

* **테스트**
  * OAuth 서비스 및 화이트리스트 설정에 대한 테스트 커버리지 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->