### PR TITLE
[FEATURE] 회원 정보 조회 API 구현

### DIFF
--- a/ssd-api/src/main/java/or/hyu/ssd/domain/member/controller/MemberController.java
+++ b/ssd-api/src/main/java/or/hyu/ssd/domain/member/controller/MemberController.java
@@ -1,0 +1,49 @@
+package or.hyu.ssd.domain.member.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import or.hyu.ssd.domain.member.controller.dto.GetMyMemberResponse;
+import or.hyu.ssd.domain.member.service.CustomUserDetails;
+import or.hyu.ssd.domain.member.service.MemberService;
+import or.hyu.ssd.global.api.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+@Tag(name = "회원 API", description = "회원 조회 관련 엔드포인트")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @GetMapping("/v1/members/me")
+    @Operation(
+            summary = "내 회원 정보 조회",
+            description = """
+                    ### 개요
+                    - 로그인한 회원의 최신 정보를 조회합니다.
+
+                    ### 인증
+                    - Authorization: Bearer {accessToken}
+
+                    ### 응답
+                    - 200 OK
+                    - data.memberId: 회원 ID
+                    - data.name: 회원명
+                    - data.email: 이메일
+                    - data.profileImageUrl: 프로필 이미지 URL
+                    - data.role: 회원 권한
+                    """
+    )
+    public ResponseEntity<ApiResponse<GetMyMemberResponse>> getMyInfo(
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        GetMyMemberResponse response = memberService.getMyInfo(user);
+        return ResponseEntity.ok(ApiResponse.ok(response, "회원 정보가 조회되었습니다"));
+    }
+}

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/member/controller/dto/GetMyMemberResponse.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/member/controller/dto/GetMyMemberResponse.java
@@ -1,0 +1,22 @@
+package or.hyu.ssd.domain.member.controller.dto;
+
+import or.hyu.ssd.domain.member.entity.Member;
+
+public record GetMyMemberResponse(
+        Long memberId,
+        String name,
+        String email,
+        String profileImageUrl,
+        String role
+) {
+
+    public static GetMyMemberResponse from(Member member) {
+        return new GetMyMemberResponse(
+                member.getId(),
+                member.getName(),
+                member.getEmail(),
+                member.getProfileImageUrl(),
+                member.getRole().name()
+        );
+    }
+}

--- a/ssd-domain/src/main/java/or/hyu/ssd/domain/member/service/MemberService.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/domain/member/service/MemberService.java
@@ -1,0 +1,27 @@
+package or.hyu.ssd.domain.member.service;
+
+import lombok.RequiredArgsConstructor;
+import or.hyu.ssd.domain.member.controller.dto.GetMyMemberResponse;
+import or.hyu.ssd.domain.member.entity.Member;
+import or.hyu.ssd.domain.member.repository.MemberRepository;
+import or.hyu.ssd.global.api.ErrorCode;
+import or.hyu.ssd.global.api.handler.UserExceptionHandler;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public GetMyMemberResponse getMyInfo(CustomUserDetails user) {
+        Long memberId = user.getMember().getId();
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new UserExceptionHandler(ErrorCode.MEMBER_NOT_FOUND));
+
+        return GetMyMemberResponse.from(member);
+    }
+}

--- a/ssd-domain/src/test/java/or/hyu/ssd/domain/member/service/MemberServiceTest.java
+++ b/ssd-domain/src/test/java/or/hyu/ssd/domain/member/service/MemberServiceTest.java
@@ -1,0 +1,68 @@
+package or.hyu.ssd.domain.member.service;
+
+import or.hyu.ssd.domain.member.controller.dto.GetMyMemberResponse;
+import or.hyu.ssd.domain.member.entity.Member;
+import or.hyu.ssd.domain.member.entity.Role;
+import or.hyu.ssd.domain.member.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private MemberService memberService;
+
+    @Test
+    @DisplayName("getMyInfo()는 로그인한 회원의 최신 정보를 반환한다")
+    void getMyInfo_returnsLatestMemberInfo() {
+        Member principalMember = member(1L, "principal@example.com", "기존 이름");
+        Member persistedMember = member(1L, "principal@example.com", "최신 이름");
+        CustomUserDetails user = new CustomUserDetails(principalMember);
+
+        when(memberRepository.findById(1L)).thenReturn(Optional.of(persistedMember));
+
+        GetMyMemberResponse response = memberService.getMyInfo(user);
+
+        assertThat(response.memberId()).isEqualTo(1L);
+        assertThat(response.name()).isEqualTo("최신 이름");
+        assertThat(response.email()).isEqualTo("principal@example.com");
+        assertThat(response.profileImageUrl()).isEqualTo("https://image.example.com/profile.png");
+        assertThat(response.role()).isEqualTo("ROLE_AUTHOR");
+    }
+
+    @Test
+    @DisplayName("getMyInfo()는 회원이 없으면 MEMBER_NOT_FOUND를 던진다")
+    void getMyInfo_throwsWhenMemberMissing() {
+        CustomUserDetails user = new CustomUserDetails(member(1L, "principal@example.com", "이름"));
+        when(memberRepository.findById(1L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> memberService.getMyInfo(user))
+                .isInstanceOf(or.hyu.ssd.global.api.handler.UserExceptionHandler.class)
+                .hasMessage("회원을 찾지 못했습니다");
+    }
+
+    private Member member(Long id, String email, String name) {
+        return Member.builder()
+                .id(id)
+                .name(name)
+                .email(email)
+                .profileImageUrl("https://image.example.com/profile.png")
+                .profileImageKey("profile-key")
+                .role(Role.ROLE_AUTHOR)
+                .build();
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #115 


<br><br>

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->


<br><br>

## 🙏 Details

<!-- 이번 PR에서 구현한 내용 중 포인트가 되는 부분을 자세하게 적어주세요 -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 인증된 사용자의 프로필 정보를 조회하는 API 엔드포인트를 추가했습니다. 사용자 ID, 이름, 이메일, 프로필 이미지 URL, 역할 정보를 확인할 수 있습니다.

* **테스트**
  * 프로필 조회 기능의 정상 작동과 오류 처리를 검증하는 단위 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->