### PR TITLE
[CHORE] CD 파이프라인 최적화

### DIFF
--- a/.github/workflows/develop-cd.yml
+++ b/.github/workflows/develop-cd.yml
@@ -81,41 +81,19 @@ jobs:
           IMAGE_SHA: ${{ github.sha }}
         run: |
           ./gradlew :ssd-api:jib -x test --no-daemon --build-cache \
-            -Djib.from.auth.username="${DOCKER_USERNAME}" \
-            -Djib.from.auth.password="${DOCKER_PASSWORD}" \
             -Djib.to.image="${DOCKER_REPO}" \
             -Djib.to.tags="${IMAGE_SHA},develop-latest" \
             -Djib.to.auth.username="${DOCKER_USERNAME}" \
             -Djib.to.auth.password="${DOCKER_PASSWORD}"
 
-      - name: 배포 파일 전송
+      - name: 배포 리소스 전송
         uses: appleboy/scp-action@v0.1.7
         with:
           host: ${{ secrets.HOST }}
           port: ${{ env.SSH_PORT }}
           username: ubuntu
           key: ${{ secrets.KEY }}
-          source: deploy/ec2
-          target: /tmp
-
-      - name: 모니터링 파일 전송
-        uses: appleboy/scp-action@v0.1.7
-        with:
-          host: ${{ secrets.HOST }}
-          port: ${{ env.SSH_PORT }}
-          username: ubuntu
-          key: ${{ secrets.KEY }}
-          source: k6/monitoring
-          target: /tmp
-
-      - name: dev 설정 파일 전송
-        uses: appleboy/scp-action@v0.1.7
-        with:
-          host: ${{ secrets.HOST }}
-          port: ${{ env.SSH_PORT }}
-          username: ubuntu
-          key: ${{ secrets.KEY }}
-          source: .runtime/application-dev.yml
+          source: "deploy/ec2,k6/monitoring,.runtime/application-dev.yml"
           target: /tmp
 
       - name: EC2 Blue/Green 배포

--- a/deploy/ec2/install_infra.sh
+++ b/deploy/ec2/install_infra.sh
@@ -16,21 +16,74 @@ NGINX_UPSTREAM_FILE="${NGINX_UPSTREAM_FILE:-/etc/nginx/conf.d/ssd-upstream.conf}
 NGINX_SITE_AVAILABLE="${NGINX_SITE_AVAILABLE:-/etc/nginx/sites-available/${NGINX_SERVER_NAME}}"
 NGINX_SITE_ENABLED="${NGINX_SITE_ENABLED:-/etc/nginx/sites-enabled/${NGINX_SERVER_NAME}}"
 
+copy_if_changed() {
+  local source_file="$1"
+  local target_file="$2"
+  local file_mode="$3"
+  local owner="${4:-}"
+
+  if [[ -f "${target_file}" ]] && cmp -s "${source_file}" "${target_file}"; then
+    if [[ -n "${owner}" ]]; then
+      chown "${owner}" "${target_file}"
+    fi
+    return 1
+  fi
+
+  install -m "${file_mode}" "${source_file}" "${target_file}"
+  if [[ -n "${owner}" ]]; then
+    chown "${owner}" "${target_file}"
+  fi
+  return 0
+}
+
+install_rendered_if_changed() {
+  local rendered_file="$1"
+  local target_file="$2"
+  local file_mode="$3"
+
+  if [[ -f "${target_file}" ]] && cmp -s "${rendered_file}" "${target_file}"; then
+    return 1
+  fi
+
+  install -m "${file_mode}" "${rendered_file}" "${target_file}"
+  return 0
+}
+
+redis_running() {
+  local container_id
+  container_id="$(docker compose -f "${INFRA_DIR}/docker-compose.yml" ps -q redis 2>/dev/null || true)"
+  [[ -n "${container_id}" ]] && [[ "$(docker inspect -f '{{.State.Running}}' "${container_id}" 2>/dev/null || true)" == "true" ]]
+}
+
 install -d -m 755 -o "${DEPLOY_USER}" -g "${DEPLOY_USER}" "${INFRA_DIR}"
 install -d -m 755 "${DEPLOY_ROOT}" "${RUNTIME_CONFIG_DIR}"
-install -m 644 "${SCRIPT_DIR}/docker-compose.yml" "${INFRA_DIR}/docker-compose.yml"
-chown "${DEPLOY_USER}:${DEPLOY_USER}" "${INFRA_DIR}/docker-compose.yml"
+
+infra_changed=0
+nginx_changed=0
+network_created=0
+
+if copy_if_changed "${SCRIPT_DIR}/docker-compose.yml" "${INFRA_DIR}/docker-compose.yml" 644 "${DEPLOY_USER}:${DEPLOY_USER}"; then
+  infra_changed=1
+fi
 
 if [[ -n "${APP_CONFIG_SOURCE}" ]]; then
-  install -m 600 "${APP_CONFIG_SOURCE}" "${APP_CONFIG_FILE}"
+  copy_if_changed "${APP_CONFIG_SOURCE}" "${APP_CONFIG_FILE}" 600 >/dev/null || true
 elif [[ ! -f "${APP_CONFIG_FILE}" ]]; then
   echo "[ERROR] application-dev.yml is required at ${APP_CONFIG_FILE}" >&2
   exit 1
 fi
 
 if command -v docker >/dev/null 2>&1; then
-  docker network inspect "${NETWORK_NAME}" >/dev/null 2>&1 || docker network create "${NETWORK_NAME}"
-  docker compose -f "${INFRA_DIR}/docker-compose.yml" up -d redis
+  if ! docker network inspect "${NETWORK_NAME}" >/dev/null 2>&1; then
+    docker network create "${NETWORK_NAME}"
+    network_created=1
+  fi
+
+  if (( infra_changed == 1 || network_created == 1 )) || ! redis_running; then
+    docker compose -f "${INFRA_DIR}/docker-compose.yml" up -d redis
+  else
+    echo "[INFO] Redis infra unchanged, skip compose up"
+  fi
 else
   echo "[ERROR] docker is not installed" >&2
   exit 1
@@ -38,8 +91,17 @@ fi
 
 if command -v nginx >/dev/null 2>&1; then
   install -d -m 755 /etc/nginx/conf.d /etc/nginx/sites-available /etc/nginx/sites-enabled
-  install -m 644 "${SCRIPT_DIR}/nginx/zzz-ssd-timeout.conf" "${NGINX_TIMEOUT_FILE}"
-  sed "s#__SERVER_NAME__#${NGINX_SERVER_NAME}#g" "${SCRIPT_DIR}/nginx/site.conf.template" > "${NGINX_SITE_AVAILABLE}"
+
+  if copy_if_changed "${SCRIPT_DIR}/nginx/zzz-ssd-timeout.conf" "${NGINX_TIMEOUT_FILE}" 644; then
+    nginx_changed=1
+  fi
+
+  rendered_site_file="$(mktemp)"
+  trap 'rm -f "${rendered_site_file}"' EXIT
+  sed "s#__SERVER_NAME__#${NGINX_SERVER_NAME}#g" "${SCRIPT_DIR}/nginx/site.conf.template" > "${rendered_site_file}"
+  if install_rendered_if_changed "${rendered_site_file}" "${NGINX_SITE_AVAILABLE}" 644; then
+    nginx_changed=1
+  fi
   ln -sfn "${NGINX_SITE_AVAILABLE}" "${NGINX_SITE_ENABLED}"
 
   if [[ ! -f "${NGINX_UPSTREAM_FILE}" ]]; then
@@ -49,10 +111,15 @@ upstream ssd_backend {
     keepalive 32;
 }
 EOF_UPSTREAM
+    nginx_changed=1
   fi
 
-  nginx -t
-  systemctl reload nginx
+  if (( nginx_changed == 1 )); then
+    nginx -t
+    systemctl reload nginx
+  else
+    echo "[INFO] Nginx infra unchanged, skip reload"
+  fi
 else
   echo "[ERROR] nginx is not installed" >&2
   exit 1

--- a/deploy/ec2/install_monitoring.sh
+++ b/deploy/ec2/install_monitoring.sh
@@ -9,6 +9,24 @@ GRAFANA_PORT="${GRAFANA_PORT:-3000}"
 PROMETHEUS_PORT="${PROMETHEUS_PORT:-9090}"
 K6_DASHBOARD_PORT="${K6_DASHBOARD_PORT:-5665}"
 
+copy_if_changed() {
+  local source_file="$1"
+  local target_file="$2"
+  local file_mode="$3"
+
+  if [[ -f "${target_file}" ]] && cmp -s "${source_file}" "${target_file}"; then
+    return 1
+  fi
+
+  install -m "${file_mode}" "${source_file}" "${target_file}"
+  return 0
+}
+
+container_running() {
+  local container_name="$1"
+  [[ "$(docker inspect -f '{{.State.Running}}' "${container_name}" 2>/dev/null || true)" == "true" ]]
+}
+
 resolve_monitoring_source_dir() {
   local candidates=()
 
@@ -45,17 +63,37 @@ install -d -m 755 \
   "${MONITORING_ROOT}/grafana/provisioning/dashboards" \
   "${MONITORING_ROOT}/grafana/dashboards"
 
-install -m 644 "${MONITORING_SOURCE_DIR}/docker-compose.monitoring.yml" "${MONITORING_COMPOSE_FILE}"
-install -m 644 "${MONITORING_SOURCE_DIR}/prometheus/prometheus.yml" "${MONITORING_ROOT}/prometheus/prometheus.yml"
-install -m 644 "${MONITORING_SOURCE_DIR}/grafana/provisioning/datasources/prometheus.yml" "${MONITORING_ROOT}/grafana/provisioning/datasources/prometheus.yml"
-install -m 644 "${MONITORING_SOURCE_DIR}/grafana/provisioning/dashboards/dashboard.yml" "${MONITORING_ROOT}/grafana/provisioning/dashboards/dashboard.yml"
-find "${MONITORING_SOURCE_DIR}/grafana/dashboards" -maxdepth 1 -type f -name '*.json' -print0 | \
-  while IFS= read -r -d '' dashboard_file; do
-    install -m 644 "${dashboard_file}" "${MONITORING_ROOT}/grafana/dashboards/$(basename "${dashboard_file}")"
-  done
+monitoring_changed=0
+
+if copy_if_changed "${MONITORING_SOURCE_DIR}/docker-compose.monitoring.yml" "${MONITORING_COMPOSE_FILE}" 644; then
+  monitoring_changed=1
+fi
+if copy_if_changed "${MONITORING_SOURCE_DIR}/prometheus/prometheus.yml" "${MONITORING_ROOT}/prometheus/prometheus.yml" 644; then
+  monitoring_changed=1
+fi
+if copy_if_changed "${MONITORING_SOURCE_DIR}/grafana/provisioning/datasources/prometheus.yml" "${MONITORING_ROOT}/grafana/provisioning/datasources/prometheus.yml" 644; then
+  monitoring_changed=1
+fi
+if copy_if_changed "${MONITORING_SOURCE_DIR}/grafana/provisioning/dashboards/dashboard.yml" "${MONITORING_ROOT}/grafana/provisioning/dashboards/dashboard.yml" 644; then
+  monitoring_changed=1
+fi
+while IFS= read -r -d '' dashboard_file; do
+  target_file="${MONITORING_ROOT}/grafana/dashboards/$(basename "${dashboard_file}")"
+  if copy_if_changed "${dashboard_file}" "${target_file}" 644; then
+    monitoring_changed=1
+  fi
+done < <(find "${MONITORING_SOURCE_DIR}/grafana/dashboards" -maxdepth 1 -type f -name '*.json' -print0)
 
 if command -v docker >/dev/null 2>&1; then
-  docker compose -f "${MONITORING_COMPOSE_FILE}" up -d
+  if (( monitoring_changed == 1 )) \
+    || ! container_running "ssd-loadtest-prometheus" \
+    || ! container_running "ssd-loadtest-grafana" \
+    || ! container_running "ssd-loadtest-node-exporter" \
+    || ! container_running "ssd-loadtest-cadvisor"; then
+    docker compose -f "${MONITORING_COMPOSE_FILE}" up -d
+  else
+    echo "[INFO] Monitoring unchanged, skip compose up"
+  fi
 else
   echo "[ERROR] docker is not installed" >&2
   exit 1

--- a/ssd-api/build.gradle
+++ b/ssd-api/build.gradle
@@ -37,7 +37,7 @@ jib {
         mainClass = 'or.hyu.ssd.SsdApplication'
         ports = ['8080']
         jvmFlags = ['-Duser.timezone=Asia/Seoul']
-        creationTime = 'USE_CURRENT_TIMESTAMP'
+        creationTime = 'EPOCH'
     }
 }
 


### PR DESCRIPTION
## 📣 Related Issue

- close #118

<br><br>

## 📝 Summary

- `develop-cd` workflow에서 배포 리소스 전송 단계를 하나로 합쳐 SSH/SCP round trip을 줄였습니다.
- 인프라/모니터링 설치 스크립트에 변경 감지 로직을 추가해, 파일과 컨테이너 상태가 그대로면 재설치 작업을 건너뛰도록 수정했습니다.
- Jib 이미지 설정의 `creationTime`을 `EPOCH`로 변경해 이미지 재현성과 레이어 캐시 효율을 개선했습니다.

<br><br>

## 🙏 Question & PR point

### 1. 파일 전송 단계를 3번에서 1번으로 줄였습니다.

기존에는 아래처럼 배포 파일, 모니터링 파일, dev 설정 파일을 각각 따로 전송하고 있었습니다.

~~~yaml
- name: 배포 파일 전송
  uses: appleboy/scp-action@v0.1.7
  with:
    host: ${{ secrets.HOST }}
    port: ${{ env.SSH_PORT }}
    username: ubuntu
    key: ${{ secrets.KEY }}
    source: deploy/ec2
    target: /tmp

- name: 모니터링 파일 전송
  uses: appleboy/scp-action@v0.1.7
  with:
    host: ${{ secrets.HOST }}
    port: ${{ env.SSH_PORT }}
    username: ubuntu
    key: ${{ secrets.KEY }}
    source: k6/monitoring
    target: /tmp

- name: dev 설정 파일 전송
  uses: appleboy/scp-action@v0.1.7
  with:
    host: ${{ secrets.HOST }}
    port: ${{ env.SSH_PORT }}
    username: ubuntu
    key: ${{ secrets.KEY }}
    source: .runtime/application-dev.yml
    target: /tmp
~~~

이번 PR에서는 이 전송 과정을 하나의 SCP 단계로 합쳤습니다.  
서버 로직 변화는 거의 없고, CD 파이프라인의 왕복 횟수를 줄이는 데 초점을 맞춘 변경입니다.

### 2. install 스크립트가 매번 동일한 작업을 반복하지 않도록 변경했습니다.

기존에는 배포 시마다 infra/monitoring 관련 파일을 다시 복사하고, compose up과 nginx reload를 반복적으로 수행했습니다.  
이번에는 파일이 실제로 변경되었는지 먼저 비교해서, 바뀐 경우에만 작업을 수행하도록 만들었습니다.

핵심 로직은 아래와 같습니다.

~~~bash
copy_if_changed() {
  local source_file="$1"
  local target_file="$2"
  local file_mode="$3"
  local owner="${4:-}"

  if [[ -f "${target_file}" ]] && cmp -s "${source_file}" "${target_file}"; then
    if [[ -n "${owner}" ]]; then
      chown "${owner}" "${target_file}"
    fi
    return 1
  fi

  install -m "${file_mode}" "${source_file}" "${target_file}"
  if [[ -n "${owner}" ]]; then
    chown "${owner}" "${target_file}"
  fi
  return 0
}
~~~

즉 이번 PR의 핵심은 “설치” 자체를 없앤 것이 아니라,   **변경이 없는 설치 작업은 반복하지 않도록 만든 것**입니다.

### 3. monitoring / infra 컨테이너도 상태가 그대로면 재기동하지 않도록 했습니다.

예를 들어 monitoring 쪽은 다음 조건일 때만 `docker compose up -d`를 다시 수행합니다.

- 관련 설정 파일이 바뀐 경우
- Prometheus / Grafana / node-exporter / cadvisor 중 하나라도 꺼져 있는 경우

즉 단순 redeploy 시에는 불필요한 compose 실행을 피할 수 있습니다.

### 4. Jib 설정도 캐시 친화적으로 조정했습니다.

기존 설정은 아래와 같았습니다.

~~~groovy
creationTime = 'USE_CURRENT_TIMESTAMP'
~~~

이 값은 빌드 시점마다 이미지 메타데이터가 바뀌기 때문에,   레이어 재현성과 캐시 효율 측면에서 불리할 수 있습니다.

이번 PR에서는 아래처럼 변경했습니다.

~~~groovy
creationTime = 'EPOCH'
~~~

이 변경은 배포 동작을 바꾸기 위한 것이 아니라,   **같은 입력이면 가능한 한 같은 이미지 레이어를 만들도록 정리한 것**에 가깝습니다.

### 5. 이번 PR은 배포 최적화 중심이고, 애플리케이션 서버 로직은 거의 바뀌지 않았습니다.

이번 PR도 서버 비즈니스 로직을 건드리는 작업은 아닙니다.  
실제 변경은 대부분 아래 영역에 집중되어 있습니다.

- GitHub Actions workflow
- infra / monitoring 설치 스크립트
- Jib 이미지 설정

즉 배포 속도를 줄이기 위한 CD 구조 개선 PR로 이해해주시면 됩니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 배포 워크플로우 최적화로 빌드 및 배포 효율성 개선
  * 인프라 설치 프로세스의 안정성 강화로 불필요한 재설정 방지
  * 파일 변경 감지 기반 조건부 서비스 시작으로 배포 시간 단축

<!-- end of auto-generated comment: release notes by coderabbit.ai -->