### PR TITLE
[FEATURE] 도커 기반 이미지 빌드 리팩터링 -> 멀티스테이징 적용

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.git
+.github
+.gradle
+.idea
+.runtime
+.DS_Store
+.vscode
+
+build
+**/build
+
+deploy
+k6
+HELP.md

--- a/.github/workflows/develop-cd.yml
+++ b/.github/workflows/develop-cd.yml
@@ -21,18 +21,6 @@ jobs:
       - name: 코드 가져오기
         uses: actions/checkout@v4
 
-      - name: JDK 21 설치
-        uses: actions/setup-java@v4
-        with:
-          java-version: '21'
-          distribution: 'temurin'
-
-      - name: Gradle 설정
-        uses: gradle/actions/setup-gradle@v3
-
-      - name: gradlew 권한 설정
-        run: chmod +x gradlew
-
       - name: application-dev.yml 생성
         env:
           APPLICATION_DEV: ${{ secrets.APPLICATION_DEV }}
@@ -74,17 +62,29 @@ jobs:
           fi
           echo "DOCKER_REPO=${DOCKER_REPO}" >> "$GITHUB_ENV"
 
-      - name: Jib 이미지 빌드 및 푸시
-        env:
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-          IMAGE_SHA: ${{ github.sha }}
-        run: |
-          ./gradlew :ssd-api:jib -x test --no-daemon --build-cache \
-            -Djib.to.image="${DOCKER_REPO}" \
-            -Djib.to.tags="${IMAGE_SHA},develop-latest" \
-            -Djib.to.auth.username="${DOCKER_USERNAME}" \
-            -Djib.to.auth.password="${DOCKER_PASSWORD}"
+      - name: Docker Buildx 설정
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker Hub 로그인
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Docker 이미지 빌드 및 푸시
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          platforms: linux/amd64
+          provenance: false
+          sbom: false
+          tags: |
+            ${{ env.DOCKER_REPO }}:${{ github.sha }}
+            ${{ env.DOCKER_REPO }}:develop-latest
+          cache-from: type=gha,scope=develop-cd-docker
+          cache-to: type=gha,mode=max,scope=develop-cd-docker
 
       - name: 배포 리소스 전송
         uses: appleboy/scp-action@v0.1.7

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 # syntax=docker/dockerfile:1.7
 
-# Build the boot jar in an isolated stage so runtime image stays slim.
+# 런타임 이미지를 가볍게 유지하기 위해 별도 stage에서 boot jar를 빌드합니다.
 FROM eclipse-temurin:21-jdk-alpine AS builder
 
 WORKDIR /workspace
 
-# Copy Gradle descriptors first to maximize dependency cache reuse.
+# Gradle 설정 파일을 먼저 복사해 의존성 캐시 재사용률을 높입니다.
 COPY gradlew gradlew.bat settings.gradle build.gradle ./
 COPY gradle ./gradle
 COPY ssd-api/build.gradle ./ssd-api/build.gradle
@@ -18,7 +18,7 @@ RUN chmod +x gradlew
 RUN --mount=type=cache,target=/root/.gradle \
     ./gradlew --no-daemon :ssd-api:dependencies >/dev/null 2>&1 || true
 
-# Source changes should only invalidate layers after dependency resolution.
+# 소스 변경이 의존성 레이어까지 깨지지 않도록 소스 복사는 뒤에서 수행합니다.
 COPY ssd-api/src ./ssd-api/src
 COPY ssd-domain/src ./ssd-domain/src
 COPY ssd-core/src ./ssd-core/src
@@ -28,7 +28,7 @@ RUN --mount=type=cache,target=/root/.gradle \
     ./gradlew --no-daemon :ssd-api:bootJar -x test && \
     cp /workspace/ssd-api/build/libs/*.jar /workspace/app.jar
 
-# Explode the boot jar so dependency and class layers can be copied separately.
+# boot jar를 풀어서 라이브러리 레이어와 클래스 레이어를 분리합니다.
 FROM eclipse-temurin:21-jdk-alpine AS extractor
 
 WORKDIR /layers
@@ -37,7 +37,7 @@ COPY --from=builder /workspace/app.jar app.jar
 
 RUN mkdir extracted && cd extracted && jar -xf ../app.jar
 
-# Final runtime image contains only the boot loader, libs, and compiled classes.
+# 최종 런타임 이미지는 boot loader, 라이브러리, 컴파일된 클래스만 포함합니다.
 FROM eclipse-temurin:21-jre-alpine
 
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,47 @@
+# syntax=docker/dockerfile:1.7
+
+FROM eclipse-temurin:21-jdk-alpine AS builder
+
+WORKDIR /workspace
+
+COPY gradlew gradlew.bat settings.gradle build.gradle ./
+COPY gradle ./gradle
+COPY ssd-api/build.gradle ./ssd-api/build.gradle
+COPY ssd-domain/build.gradle ./ssd-domain/build.gradle
+COPY ssd-core/build.gradle ./ssd-core/build.gradle
+COPY ssd-infra/build.gradle ./ssd-infra/build.gradle
+
+RUN chmod +x gradlew
+
+RUN --mount=type=cache,target=/root/.gradle \
+    ./gradlew --no-daemon :ssd-api:dependencies >/dev/null 2>&1 || true
+
+COPY ssd-api/src ./ssd-api/src
+COPY ssd-domain/src ./ssd-domain/src
+COPY ssd-core/src ./ssd-core/src
+COPY ssd-infra/src ./ssd-infra/src
+
+RUN --mount=type=cache,target=/root/.gradle \
+    ./gradlew --no-daemon :ssd-api:bootJar -x test && \
+    cp /workspace/ssd-api/build/libs/*.jar /workspace/app.jar
+
+FROM eclipse-temurin:21-jdk-alpine AS extractor
+
+WORKDIR /layers
+
+COPY --from=builder /workspace/app.jar app.jar
+
+RUN mkdir extracted && cd extracted && jar -xf ../app.jar
+
 FROM eclipse-temurin:21-jre-alpine
 
-COPY ssd-api/build/libs/ssd-api-0.0.1-SNAPSHOT.jar /app.jar
+WORKDIR /app
 
-CMD ["java", "-Dspring.profiles.active=dev", "-jar", "/app.jar"]
+COPY --from=extractor /layers/extracted/org ./org
+COPY --from=extractor /layers/extracted/META-INF ./META-INF
+COPY --from=extractor /layers/extracted/BOOT-INF/lib ./BOOT-INF/lib
+COPY --from=extractor /layers/extracted/BOOT-INF/classes ./BOOT-INF/classes
+
+EXPOSE 8080
+
+CMD ["java", "-Dspring.profiles.active=dev", "-Duser.timezone=Asia/Seoul", "org.springframework.boot.loader.launch.JarLauncher"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 # syntax=docker/dockerfile:1.7
 
+# Build the boot jar in an isolated stage so runtime image stays slim.
 FROM eclipse-temurin:21-jdk-alpine AS builder
 
 WORKDIR /workspace
 
+# Copy Gradle descriptors first to maximize dependency cache reuse.
 COPY gradlew gradlew.bat settings.gradle build.gradle ./
 COPY gradle ./gradle
 COPY ssd-api/build.gradle ./ssd-api/build.gradle
@@ -16,6 +18,7 @@ RUN chmod +x gradlew
 RUN --mount=type=cache,target=/root/.gradle \
     ./gradlew --no-daemon :ssd-api:dependencies >/dev/null 2>&1 || true
 
+# Source changes should only invalidate layers after dependency resolution.
 COPY ssd-api/src ./ssd-api/src
 COPY ssd-domain/src ./ssd-domain/src
 COPY ssd-core/src ./ssd-core/src
@@ -25,6 +28,7 @@ RUN --mount=type=cache,target=/root/.gradle \
     ./gradlew --no-daemon :ssd-api:bootJar -x test && \
     cp /workspace/ssd-api/build/libs/*.jar /workspace/app.jar
 
+# Explode the boot jar so dependency and class layers can be copied separately.
 FROM eclipse-temurin:21-jdk-alpine AS extractor
 
 WORKDIR /layers
@@ -33,6 +37,7 @@ COPY --from=builder /workspace/app.jar app.jar
 
 RUN mkdir extracted && cd extracted && jar -xf ../app.jar
 
+# Final runtime image contains only the boot loader, libs, and compiled classes.
 FROM eclipse-temurin:21-jre-alpine
 
 WORKDIR /app

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,6 @@ pluginManagement {
     plugins {
         id 'org.springframework.boot' version '4.0.0'
         id 'io.spring.dependency-management' version '1.1.7'
-        id 'com.google.cloud.tools.jib' version '3.4.5'
     }
 }
 

--- a/ssd-api/build.gradle
+++ b/ssd-api/build.gradle
@@ -2,7 +2,6 @@ plugins {
     id 'org.springframework.boot'
     id 'java'
     id 'jacoco'
-    id 'com.google.cloud.tools.jib'
 }
 
 dependencies {
@@ -29,15 +28,9 @@ jacoco {
     toolVersion = '0.8.12'
 }
 
-jib {
-    from {
-        image = 'eclipse-temurin:21-jre-alpine'
-    }
-    container {
-        mainClass = 'or.hyu.ssd.SsdApplication'
-        ports = ['8080']
-        jvmFlags = ['-Duser.timezone=Asia/Seoul']
-        creationTime = 'EPOCH'
+bootJar {
+    layered {
+        enabled = true
     }
 }
 


### PR DESCRIPTION
## 📣 Related Issue

- close #122

<br><br>

## 📝 Summary

- 이미지 빌드 방식을 Jib에서 Docker buildx 기반으로 전환하였습니다.
- `.dockerignore`를 추가하여 Docker build context를 줄이고, 불필요한 파일이 이미지 빌드에 포함되지 않도록 정리하였습니다.
- Dockerfile을 멀티스테이지 기반으로 재작성하여 build 단계와 runtime 단계를 분리하고, Spring Boot jar 내부 레이어를 직접 나누는 방식으로 변경하였습니다.

<br><br>

## 🙏 Details

### 1. Jib -> Docker buildx 기반 이미지 빌드로 전환하였습니다.

기존에는 Jib를 통해 Gradle에서 바로 이미지를 생성하고 푸시하고 있었습니다.

Jib는 Gradle/Maven 플러그인으로 Docker daemon 없이 Java 앱에서 바로 이미지 레이어를 만듭니다.  
그래서 Java 프로젝트에서는 설정이 간단하고, 기본적인 레이어 분리도 자동으로 잘 해준다는 장점이 있습니다.

다만 이번 이슈에서는 단순히 이미지를 만드는 것보다,  
**내부 이미지 레이어를 직접 제어하고 GitHub Actions cache와 결합하여 CD 시간을 줄이는 것**이 더 중요했습니다.

Jib는 이런 목적에서는 다음 한계가 있다고 판단했습니다.

- 내부 레이어 기준을 세밀하게 커스텀하기가 제한적임
- Dockerfile 기반 멀티스테이지 최적화보다 유연성이 떨어짐
- buildx cache 전략과 함께 전체 파이프라인을 설계하기에는 제약이 있음

그래서 빌드 방식을 Docker buildx 기반으로 변경하였습니다.

~~~yaml
- name: Docker Buildx 설정
  uses: docker/setup-buildx-action@v3

- name: Docker Hub 로그인
  uses: docker/login-action@v3
  with:
    username: ${{ secrets.DOCKER_USERNAME }}
    password: ${{ secrets.DOCKER_PASSWORD }}

- name: Docker 이미지 빌드 및 푸시
  uses: docker/build-push-action@v6
  with:
    context: .
    file: ./Dockerfile
    push: true
    platforms: linux/amd64
    provenance: false
    sbom: false
    tags: |
      ${{ env.DOCKER_REPO }}:${{ github.sha }}
      ${{ env.DOCKER_REPO }}:develop-latest
    cache-from: type=gha,scope=develop-cd-docker
    cache-to: type=gha,mode=max,scope=develop-cd-docker
~~~

핵심은 `cache-from`, `cache-to`를 통해 GitHub Actions cache를 이미지 빌드 레이어와 직접 연결한 부분입니다.  
즉 다음 배포에서 동일한 빌드 입력이 유지되면, 이전 레이어를 재사용할 가능성이 생깁니다.

---

### 2. `.dockerignore`를 추가하였습니다.

최근 모니터링 시스템, 배포 스크립트, 로컬 캐시 파일 등이 늘어나면서  
애플리케이션 이미지 빌드와 무관한 파일들도 저장소 루트에 많이 존재하게 되었습니다.

Docker build는 기본적으로 context 디렉토리 전체를 참조하기 때문에,  
이런 파일들을 그대로 두면 아래 문제가 발생할 수 있습니다.

- build context가 불필요하게 커짐
- 이미지 빌드 시작 자체가 느려짐
- 실제 코드 변경과 무관한 파일 때문에 캐시가 깨질 가능성이 커짐

그래서 `.dockerignore`를 추가하였습니다.

~~~dockerignore
.git
.github
.gradle
.idea
.runtime
.DS_Store
.vscode

build
**/build

deploy
k6
HELP.md
~~~

이번 PR에서 제외한 파일들의 의도는 명확합니다.

- `.git`, `.github`, `.idea`, `.vscode`
  - 이미지 실행과 무관한 메타데이터
- `.gradle`, `build`, `**/build`
  - 이전 로컬 빌드 산출물 및 캐시
- `deploy`, `k6`
  - 배포/부하테스트 스크립트로, 애플리케이션 이미지 실행에는 직접 필요하지 않음
- `.runtime`
  - CI에서 생성되는 임시 설정 파일
- `HELP.md`
  - 실행과 무관한 문서 파일

즉 `.dockerignore`의 목적은 단순히 파일을 빼는 것이 아니라,   **이미지 빌드에 필요한 입력만 남겨서 Docker cache가 덜 깨지게 만드는 것**입니다.

---

### 3. Dockerfile을 멀티스테이지 방식으로 재작성하였습니다.

전체 구조는 크게 3단계입니다.

#### 1) builder stage
- Gradle build를 수행하는 단계
- 소스코드를 컴파일하고 Spring Boot jar를 생성합니다.

#### 2) extractor stage
- 생성된 jar를 풀어서 내부 구조를 직접 나눕니다.

#### 3) runtime stage
- 실제 실행에 필요한 레이어만 복사해서 최종 이미지를 구성합니다.

이번에 작성한 Dockerfile은 아래와 같습니다.

~~~dockerfile
# syntax=docker/dockerfile:1.7

FROM eclipse-temurin:21-jdk-alpine AS builder

WORKDIR /workspace

COPY gradlew gradlew.bat settings.gradle build.gradle ./
COPY gradle ./gradle
COPY ssd-api/build.gradle ./ssd-api/build.gradle
COPY ssd-domain/build.gradle ./ssd-domain/build.gradle
COPY ssd-core/build.gradle ./ssd-core/build.gradle
COPY ssd-infra/build.gradle ./ssd-infra/build.gradle

RUN chmod +x gradlew

RUN --mount=type=cache,target=/root/.gradle \
    ./gradlew --no-daemon :ssd-api:dependencies >/dev/null 2>&1 || true

COPY ssd-api/src ./ssd-api/src
COPY ssd-domain/src ./ssd-domain/src
COPY ssd-core/src ./ssd-core/src
COPY ssd-infra/src ./ssd-infra/src

RUN --mount=type=cache,target=/root/.gradle \
    ./gradlew --no-daemon :ssd-api:bootJar -x test && \
    cp /workspace/ssd-api/build/libs/*.jar /workspace/app.jar

FROM eclipse-temurin:21-jdk-alpine AS extractor

WORKDIR /layers

COPY --from=builder /workspace/app.jar app.jar

RUN mkdir extracted && cd extracted && jar -xf ../app.jar

FROM eclipse-temurin:21-jre-alpine

WORKDIR /app

COPY --from=extractor /layers/extracted/org ./org
COPY --from=extractor /layers/extracted/META-INF ./META-INF
COPY --from=extractor /layers/extracted/BOOT-INF/lib ./BOOT-INF/lib
COPY --from=extractor /layers/extracted/BOOT-INF/classes ./BOOT-INF/classes

EXPOSE 8080

CMD ["java", "-Dspring.profiles.active=dev", "-Duser.timezone=Asia/Seoul", "org.springframework.boot.loader.launch.JarLauncher"]
~~~

이 구조의 의도는 아래와 같습니다.

#### 3-1. build 관련 파일을 먼저 복사합니다.

~~~dockerfile
COPY gradlew gradlew.bat settings.gradle build.gradle ./
COPY gradle ./gradle
COPY ssd-api/build.gradle ./ssd-api/build.gradle
COPY ssd-domain/build.gradle ./ssd-domain/build.gradle
COPY ssd-core/build.gradle ./ssd-core/build.gradle
COPY ssd-infra/build.gradle ./ssd-infra/build.gradle
~~~

이 단계에서는 아직 전체 소스를 복사하지 않습니다.  
먼저 Gradle wrapper와 build script들만 복사해서, 의존성 관련 레이어가 소스 변경 때문에 쉽게 깨지지 않도록 구성했습니다.

즉 앱 코드가 조금 바뀌어도
- dependency resolution
- plugin resolution
같은 상대적으로 무거운 단계는 캐시를 탈 가능성이 높아집니다.

#### 3-2. Gradle cache mount를 사용합니다.

~~~dockerfile
RUN --mount=type=cache,target=/root/.gradle \
    ./gradlew --no-daemon :ssd-api:dependencies >/dev/null 2>&1 || true
~~~

그리고 build 단계에서도 동일하게 cache mount를 사용합니다.

~~~dockerfile
RUN --mount=type=cache,target=/root/.gradle \
    ./gradlew --no-daemon :ssd-api:bootJar -x test && \
    cp /workspace/ssd-api/build/libs/*.jar /workspace/app.jar
~~~

이렇게 하면 Docker build 레이어뿐 아니라, Gradle dependency cache도 build 과정에서 재사용할 수 있습니다.

즉 이번 전환의 포인트는 단순 Dockerfile이 아니라 **Docker layer cache + Gradle cache를 함께 활용하는 구조**를 만든 것입니다.

#### 3-3. jar를 그대로 복사하지 않고 한 번 풀어서 레이어를 나눕니다.

예전 Dockerfile은 사실상 아래와 같았습니다.

~~~dockerfile
FROM eclipse-temurin:21-jre-alpine

COPY ssd-api/build/libs/ssd-api-0.0.1-SNAPSHOT.jar /app.jar

CMD ["java", "-Dspring.profiles.active=dev", "-jar", "/app.jar"]
~~~

이 방식은 구현은 단순하지만, jar 파일 하나가 통째로 하나의 레이어처럼 움직입니다.  
즉 클래스 한 줄만 바뀌어도 결과 jar 전체가 바뀌고, 캐시 이점이 줄어들 수 있습니다.

이번에는 jar를 extract한 뒤 아래를 분리했습니다.

~~~dockerfile
COPY --from=extractor /layers/extracted/org ./org
COPY --from=extractor /layers/extracted/META-INF ./META-INF
COPY --from=extractor /layers/extracted/BOOT-INF/lib ./BOOT-INF/lib
COPY --from=extractor /layers/extracted/BOOT-INF/classes ./BOOT-INF/classes
~~~

이 구조의 장점은 다음과 같습니다.

- `BOOT-INF/lib`
  - 의존성 라이브러리 레이어
- `BOOT-INF/classes`
  - 실제 애플리케이션 클래스 레이어

즉 코드만 조금 바뀌는 경우엔 `BOOT-INF/classes` 중심으로 변경되고, 의존성 레이어는 그대로 재사용될 가능성이 높아집니다.

#### 3-4. runtime 이미지에는 JRE만 사용합니다.

builder와 extractor 단계는 JDK 이미지를 사용하지만, 최종 runtime stage는 JRE 이미지를 사용합니다.

~~~dockerfile
FROM eclipse-temurin:21-jre-alpine
~~~

이렇게 하면
- 빌드 도구는 최종 이미지에 남지 않고
- 실행에 필요한 최소 구성만 남기게 됩니다.

즉 이미지 용량과 실행 환경을 분리하는 전형적인 멀티스테이지 패턴을 따랐습니다.

---

### 4. Jib를 제거하고 Docker 기반 구조로 정리하였습니다.

이번 PR에서는 Jib 설정도 같이 제거했습니다.

기존에는 `ssd-api/build.gradle`, `settings.gradle`에 Jib 관련 설정이 있었습니다.

이번에는
- `com.google.cloud.tools.jib` 플러그인 제거
- `jib { ... }` 블록 제거
- 대신 `bootJar` layered 설정 추가

로 구조를 바꾸었습니다.

~~~groovy
bootJar {
    layered {
        enabled = true
    }
}
~~~

이 설정은 Spring Boot jar 자체도 레이어 구조를 더 잘 유지하도록 돕는 역할을 합니다.

---

<br><br>

해당 설정만으로 CD시간이 확연히 줄어들 것이라는 보장을 하기가 힘들어서 차근차근 디벨롭 해보도록 하겠습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 변경 사항

* **Chores**
  * Docker 빌드 컨텍스트에서 불필요한 파일/디렉터리를 제외하도록 구성했습니다.
  * CI 워크플로우에 Docker 네이티브 빌드·푸시와 빌드 캐시를 도입했습니다.
* **Refactor**
  * 이미지 빌드를 다단계로 재구성하여 빌드 효율성과 런타임 이미지를 최적화했습니다.
* **Chores**
  * 기존의 이미지 빌드 플러그인 설정을 제거하고 Spring Boot 계층화된 패키징을 활성화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->