### PR TITLE
[CHORE] CI&CD 역할 분리

### DIFF
--- a/.github/workflows/develop-cd.yml
+++ b/.github/workflows/develop-cd.yml
@@ -1,11 +1,12 @@
 name: develop-cd
 
 on:
-  push:
-    branches: [ "develop" ]
+  workflow_run:
+    workflows: ["develop-ci"]
+    types: [completed]
 
 concurrency:
-  group: develop-cd-${{ github.ref }}
+  group: develop-cd-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: true
 
 permissions:
@@ -13,6 +14,7 @@ permissions:
 
 jobs:
   deploy:
+    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'develop'
     runs-on: ubuntu-latest
     env:
       SSH_PORT: 2222
@@ -20,6 +22,8 @@ jobs:
     steps:
       - name: 코드 가져오기
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: application-dev.yml 생성
         env:
@@ -62,30 +66,6 @@ jobs:
           fi
           echo "DOCKER_REPO=${DOCKER_REPO}" >> "$GITHUB_ENV"
 
-      - name: Docker Buildx 설정
-        uses: docker/setup-buildx-action@v3
-
-      - name: Docker Hub 로그인
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Docker 이미지 빌드 및 푸시
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ./Dockerfile
-          push: true
-          platforms: linux/amd64
-          provenance: false
-          sbom: false
-          tags: |
-            ${{ env.DOCKER_REPO }}:${{ github.sha }}
-            ${{ env.DOCKER_REPO }}:develop-latest
-          cache-from: type=gha,scope=develop-cd-docker
-          cache-to: type=gha,mode=max,scope=develop-cd-docker
-
       - name: 배포 리소스 전송
         uses: appleboy/scp-action@v0.1.7
         with:
@@ -108,7 +88,7 @@ jobs:
             chmod +x /tmp/deploy/ec2/install_infra.sh /tmp/deploy/ec2/install_monitoring.sh /tmp/deploy/ec2/blue_green_deploy.sh
             export APP_NAME="ssd"
             export DOCKER_REPO="${{ env.DOCKER_REPO }}"
-            export IMAGE_TAG="${{ github.sha }}"
+            export IMAGE_TAG="${{ github.event.workflow_run.head_sha }}"
             export SPRING_PROFILES_ACTIVE="dev"
             export APP_CONFIG_SOURCE="/tmp/.runtime/application-dev.yml"
             export APP_CONFIG_FILE="/opt/ssd/config/application-dev.yml"

--- a/.github/workflows/develop-ci.yml
+++ b/.github/workflows/develop-ci.yml
@@ -2,14 +2,25 @@ name: develop-ci
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, reopened]
     branches: [main]
     paths:
-      - 'src/**'
+      - 'ssd-api/**'
+      - 'ssd-domain/**'
+      - 'ssd-core/**'
+      - 'ssd-infra/**'
       - 'build.gradle'
+      - 'settings.gradle'
+      - '.github/workflows/develop-ci.yml'
+  push:
+    branches: ["develop"]
+
+permissions:
+  contents: read
 
 jobs:
-  ci:
+  pr-check:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -17,7 +28,6 @@ jobs:
       pull-requests: write
 
     steps:
-
       - name: 코드 가져오기
         uses: actions/checkout@v4
 
@@ -32,7 +42,7 @@ jobs:
         with:
           gradle-version: '8.8'
 
-      - name: gradlew 권한 설장
+      - name: gradlew 권한 설정
         run: chmod +x gradlew
 
       - name: 빌드 및 자코코 실행
@@ -69,3 +79,46 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         if: always()
+
+  build-image:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 코드 가져오기
+        uses: actions/checkout@v4
+
+      - name: Docker 레포지토리 이름 정규화
+        env:
+          RAW_DOCKER_REPO: ${{ secrets.DOCKER_REPO }}
+        run: |
+          if [[ "${RAW_DOCKER_REPO##*/}" == *:* ]]; then
+            DOCKER_REPO="${RAW_DOCKER_REPO%:*}"
+          else
+            DOCKER_REPO="${RAW_DOCKER_REPO}"
+          fi
+          echo "DOCKER_REPO=${DOCKER_REPO}" >> "$GITHUB_ENV"
+
+      - name: Docker Buildx 설정
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker Hub 로그인
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Docker 이미지 빌드 및 푸시
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          platforms: linux/amd64
+          provenance: false
+          sbom: false
+          tags: |
+            ${{ env.DOCKER_REPO }}:${{ github.sha }}
+            ${{ env.DOCKER_REPO }}:develop-latest
+          cache-from: type=gha,scope=develop-ci-docker
+          cache-to: type=gha,mode=max,scope=develop-ci-docker


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #124 


<br><br>

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

가장 많은 시간을 차지하는 이미지 빌드를 CI로 이전하였습니다.
기존과 같은 코드를 이용하기 때문에 풀캐싱으로 아마 빌드시간이 매우 짧을 것으로 예상됩니다.

CI와 CD의 역할이 명확히 분리되었기에, 디버깅도 보다 편리해질 것이라 생각합니다.

```
  build-image:
    if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
    runs-on: ubuntu-latest

    steps:
      - name: 코드 가져오기
        uses: actions/checkout@v4

      - name: Docker 레포지토리 이름 정규화
        env:
          RAW_DOCKER_REPO: ${{ secrets.DOCKER_REPO }}
        run: |
          if [[ "${RAW_DOCKER_REPO##*/}" == *:* ]]; then
            DOCKER_REPO="${RAW_DOCKER_REPO%:*}"
          else
            DOCKER_REPO="${RAW_DOCKER_REPO}"
          fi
          echo "DOCKER_REPO=${DOCKER_REPO}" >> "$GITHUB_ENV"
      - name: Docker Buildx 설정
        uses: docker/setup-buildx-action@v3

      - name: Docker Hub 로그인
        uses: docker/login-action@v3
        with:
          username: ${{ secrets.DOCKER_USERNAME }}
          password: ${{ secrets.DOCKER_PASSWORD }}

      - name: Docker 이미지 빌드 및 푸시
        uses: docker/build-push-action@v6
        with:
          context: .
          file: ./Dockerfile
          push: true
          platforms: linux/amd64
          provenance: false
          sbom: false
          tags: |
            ${{ env.DOCKER_REPO }}:${{ github.sha }}
            ${{ env.DOCKER_REPO }}:develop-latest
          cache-from: type=gha,scope=develop-ci-docker
          cache-to: type=gha,mode=max,scope=develop-ci-docker
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **Chores**
  * 지속적 통합 및 배포 워크플로우가 재구성되었습니다.
  * 빌드 프로세스가 최적화되어 효율성이 개선되었습니다.
  * 워크플로우 트리거 메커니즘이 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->