### PR TITLE
[FEATURE] 로그아웃 API 구현

### DIFF
--- a/ssd-api/src/main/java/or/hyu/ssd/SsdApplication.java
+++ b/ssd-api/src/main/java/or/hyu/ssd/SsdApplication.java
@@ -11,5 +11,4 @@ public class SsdApplication {
     public static void main(String[] args) {
         SpringApplication.run(SsdApplication.class, args);
     }
-
 }

--- a/ssd-api/src/main/java/or/hyu/ssd/global/jwt/controller/JWTController.java
+++ b/ssd-api/src/main/java/or/hyu/ssd/global/jwt/controller/JWTController.java
@@ -93,4 +93,31 @@ public class JWTController {
 
         return ResponseEntity.ok(ApiResponse.ok("성공적으로 재생성되었습니다"));
     }
+
+    @PostMapping("/logout")
+    @Operation(
+            summary = "로그아웃 API",
+            description = """
+                    ### 개요
+                    - 현재 로그인한 사용자의 리프레시 토큰을 무효화하고 리프레시 쿠키를 만료시킵니다.
+
+                    ### 요청
+                    - POST /logout
+                    - 헤더: Authorization: Bearer {accessToken}
+
+                    ### 응답
+                    - 200 OK
+                    - refresh-token 쿠키 만료
+
+                    ### 주의
+                    - 기존 access 토큰은 만료 시점까지 유효하며, 이후 재발급은 불가능합니다.
+                    """
+    )
+    public ResponseEntity<ApiResponse<String>> logout(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                      HttpServletResponse response) {
+
+        jwtService.logout(userDetails.getMember().getId(), response);
+
+        return ResponseEntity.ok(ApiResponse.ok(null, "성공적으로 로그아웃되었습니다"));
+    }
 }

--- a/ssd-core/src/main/java/or/hyu/ssd/global/util/CookieUtil.java
+++ b/ssd-core/src/main/java/or/hyu/ssd/global/util/CookieUtil.java
@@ -1,7 +1,5 @@
 package or.hyu.ssd.global.util;
 
-import io.micrometer.common.lang.Nullable;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseCookie;
@@ -36,6 +34,23 @@ public class CookieUtil {
         ResponseCookie cookie = builder.build();
 
         response.addHeader("Set-Cookie", cookie.toString());
+    }
+
+    public static void expireSameSiteCookie(HttpServletResponse response,
+                                            String name,
+                                            String domain,
+                                            boolean secure,
+                                            String sameSite) {
+
+        addSameSiteCookie(
+                response,
+                name,
+                "",
+                0,
+                domain,
+                secure,
+                sameSite
+        );
     }
 
 }

--- a/ssd-domain/src/main/java/or/hyu/ssd/global/jwt/service/JWTService.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/global/jwt/service/JWTService.java
@@ -84,4 +84,16 @@ public class JWTService {
 
 
     }
+
+    public void logout(Long userId, HttpServletResponse response) {
+        refreshTokenRedisTemplateUtil.deleteById(userId);
+
+        CookieUtil.expireSameSiteCookie(
+                response,
+                "refresh-token",
+                cookieConfig.getDomain(),
+                cookieConfig.isSecure(),
+                cookieConfig.getSameSite()
+        );
+    }
 }

--- a/ssd-domain/src/test/java/or/hyu/ssd/global/jwt/service/JWTServiceTest.java
+++ b/ssd-domain/src/test/java/or/hyu/ssd/global/jwt/service/JWTServiceTest.java
@@ -1,0 +1,75 @@
+package or.hyu.ssd.global.jwt.service;
+
+import jakarta.servlet.http.HttpServletResponse;
+import or.hyu.ssd.domain.member.repository.MemberRepository;
+import or.hyu.ssd.domain.member.valid.RefreshTokenValidator;
+import or.hyu.ssd.global.config.properties.CookieConfig;
+import or.hyu.ssd.global.config.properties.JWTConfig;
+import or.hyu.ssd.global.jwt.JWTUtil;
+import or.hyu.ssd.global.jwt.repository.RefreshTokenRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class JWTServiceTest {
+
+    @Mock
+    private JWTUtil jwtUtil;
+    @Mock
+    private MemberRepository memberRepository;
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+    @Mock
+    private RefreshTokenValidator refreshTokenValidator;
+
+    private JWTConfig jwtConfig;
+    private CookieConfig cookieConfig;
+    private JWTService jwtService;
+
+    @BeforeEach
+    void setUp() {
+        jwtConfig = new JWTConfig();
+        jwtConfig.setAccessTokenValidityInSeconds(3600L);
+        jwtConfig.setRefreshTokenValidityInSeconds(2592000L);
+
+        cookieConfig = new CookieConfig();
+        ReflectionTestUtils.setField(cookieConfig, "domain", "example.com");
+        ReflectionTestUtils.setField(cookieConfig, "secure", true);
+        ReflectionTestUtils.setField(cookieConfig, "sameSite", "None");
+
+        jwtService = new JWTService(
+                jwtUtil,
+                jwtConfig,
+                memberRepository,
+                refreshTokenRepository,
+                cookieConfig,
+                refreshTokenValidator
+        );
+    }
+
+    @Test
+    @DisplayName("logout()은 Redis refresh token을 삭제하고 refresh-token 쿠키를 만료시킨다")
+    void logout_deletesRefreshTokenAndExpiresCookie() {
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        jwtService.logout(1L, response);
+
+        verify(refreshTokenRepository).deleteById(1L);
+        assertThat(response.getHeader("Set-Cookie"))
+                .contains("refresh-token=")
+                .contains("Max-Age=0")
+                .contains("Domain=example.com")
+                .contains("SameSite=None")
+                .contains("Secure")
+                .contains("HttpOnly");
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #117 


<br><br>

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

쿠키만료를 활용한 로그아웃을 구현하였습니다.


<br><br>

## 🙏 Details

<!-- 이번 PR에서 구현한 내용 중 포인트가 되는 부분을 자세하게 적어주세요 -->

간단하게 현재 사용자의 쿠키를 유효시간을 만료시킨 쿠키로 변동하여 주입하는 방식으로 구현하였습니다.

```java
    public static void expireSameSiteCookie(HttpServletResponse response,
                                            String name,
                                            String domain,
                                            boolean secure,
                                            String sameSite) {

        addSameSiteCookie(
                response,
                name,
                "",
                0,
                domain,
                secure,
                sameSite
        );
    }
```

따라오는 이슈로 기존의 `accessToken blacklist` 처리가 있는데요. 이는 기존 사용자를 block 시키는 로직 등 다양하게 이용 될 수 있기 때문에, 별도의 이슈에서 구현하도록 하겠습니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사용자 로그아웃 기능 — 리프레시 토큰 무효화 및 인증 쿠키 즉시 만료로 안전한 로그아웃 제공, 향상된 쿠키 정책 적용.

* **테스트**
  * 로그아웃 동작(토큰 삭제 및 쿠키 만료)을 검증하는 단위 테스트 추가.

* **잡일(Chore)**
  * 프로젝트 파일 포맷 정리(불필요 공백 제거).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->