### PR TITLE
[FEATURE] 액세스 토큰 블랙리스트 구현

### DIFF
--- a/ssd-api/src/main/java/or/hyu/ssd/global/jwt/JWTFilter.java
+++ b/ssd-api/src/main/java/or/hyu/ssd/global/jwt/JWTFilter.java
@@ -54,8 +54,7 @@ public class JWTFilter extends OncePerRequestFilter{
             setErrorResponse(response, ErrorCode.ACCESS_INVALID_TYPE);
             return;
         }
-        // Bearer 뒤의 토큰을 추출
-        String accessToken = authorizationHeader.substring(7).trim();
+        String accessToken = BearerTokenExtractor.extract(authorizationHeader);
 
         try {
             jwtUtil.isExpired(accessToken);

--- a/ssd-api/src/main/java/or/hyu/ssd/global/jwt/JWTFilter.java
+++ b/ssd-api/src/main/java/or/hyu/ssd/global/jwt/JWTFilter.java
@@ -14,6 +14,7 @@ import or.hyu.ssd.domain.member.service.CustomUserDetailsService;
 import or.hyu.ssd.global.api.ErrorCode;
 import or.hyu.ssd.global.api.handler.UserExceptionHandler;
 import or.hyu.ssd.global.config.properties.JWTConfig;
+import or.hyu.ssd.global.jwt.repository.AccessTokenBlacklistRepository;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -37,6 +38,7 @@ public class JWTFilter extends OncePerRequestFilter{
     private final JWTUtil jwtUtil;
     private final JWTConfig jwtConfig;
     private final CustomUserDetailsService customUserDetailsService;
+    private final AccessTokenBlacklistRepository accessTokenBlacklistRepository;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
@@ -60,6 +62,11 @@ public class JWTFilter extends OncePerRequestFilter{
             String category = jwtUtil.getCategory(accessToken);
             if (!"access".equals(category)) {
                 setErrorResponse(response, ErrorCode.ACCESS_INVALID_TYPE);
+                return;
+            }
+            String jti = jwtUtil.getJti(accessToken);
+            if (accessTokenBlacklistRepository.exists(jti)) {
+                setErrorResponse(response, ErrorCode.ACCESS_TOKEN_BLACKLISTED);
                 return;
             }
             Long id = jwtUtil.getId(accessToken);

--- a/ssd-api/src/main/java/or/hyu/ssd/global/jwt/controller/JWTController.java
+++ b/ssd-api/src/main/java/or/hyu/ssd/global/jwt/controller/JWTController.java
@@ -7,6 +7,8 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import or.hyu.ssd.domain.member.service.CustomUserDetails;
+import or.hyu.ssd.global.config.properties.JWTConfig;
+import or.hyu.ssd.global.jwt.BearerTokenExtractor;
 import or.hyu.ssd.global.jwt.service.JWTService;
 import or.hyu.ssd.global.api.ApiResponse;
 import org.springframework.http.ResponseEntity;
@@ -22,6 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class JWTController {
 
     private final JWTService jwtService;
+    private final JWTConfig jwtConfig;
 
     @GetMapping("/access")
     @Operation(
@@ -110,14 +113,15 @@ public class JWTController {
                     - refresh-token 쿠키 만료
 
                     ### 주의
-                    - 기존 access 토큰은 만료 시점까지 유효하며, 이후 재발급은 불가능합니다.
+                    - 로그아웃 시 access 토큰은 즉시 블랙리스트에 등록되어 무효화됩니다.
                     """
     )
     public ResponseEntity<ApiResponse<String>> logout(@AuthenticationPrincipal CustomUserDetails userDetails,
                                                       HttpServletRequest request,
                                                       HttpServletResponse response) {
+        String accessToken = BearerTokenExtractor.extract(request.getHeader(jwtConfig.getHeader()));
 
-        jwtService.logout(userDetails.getMember().getId(), request, response);
+        jwtService.logout(userDetails.getMember().getId(), accessToken, response);
 
         return ResponseEntity.ok(ApiResponse.ok(null, "성공적으로 로그아웃되었습니다"));
     }

--- a/ssd-api/src/main/java/or/hyu/ssd/global/jwt/controller/JWTController.java
+++ b/ssd-api/src/main/java/or/hyu/ssd/global/jwt/controller/JWTController.java
@@ -114,9 +114,10 @@ public class JWTController {
                     """
     )
     public ResponseEntity<ApiResponse<String>> logout(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                      HttpServletRequest request,
                                                       HttpServletResponse response) {
 
-        jwtService.logout(userDetails.getMember().getId(), response);
+        jwtService.logout(userDetails.getMember().getId(), request, response);
 
         return ResponseEntity.ok(ApiResponse.ok(null, "성공적으로 로그아웃되었습니다"));
     }

--- a/ssd-api/src/test/java/or/hyu/ssd/global/jwt/JWTFilterTest.java
+++ b/ssd-api/src/test/java/or/hyu/ssd/global/jwt/JWTFilterTest.java
@@ -85,6 +85,8 @@ class JWTFilterTest {
         request.addHeader("Authorization", "Bearer valid-token");
         when(jwtUtil.isExpired("valid-token")).thenReturn(false);
         when(jwtUtil.getCategory("valid-token")).thenReturn("access");
+        when(jwtUtil.getJti("valid-token")).thenReturn("test-jti");
+        when(accessTokenBlacklistRepository.exists("test-jti")).thenReturn(false);
         when(jwtUtil.getId("valid-token")).thenReturn(1L);
         when(jwtUtil.getRole("valid-token")).thenReturn("ROLE_AUTHOR");
         when(customUserDetailsService.loadUserById(1L))

--- a/ssd-api/src/test/java/or/hyu/ssd/global/jwt/JWTFilterTest.java
+++ b/ssd-api/src/test/java/or/hyu/ssd/global/jwt/JWTFilterTest.java
@@ -11,6 +11,7 @@ import or.hyu.ssd.domain.member.service.CustomUserDetailsService;
 import or.hyu.ssd.global.api.ErrorCode;
 import or.hyu.ssd.global.api.handler.UserExceptionHandler;
 import or.hyu.ssd.global.config.properties.JWTConfig;
+import or.hyu.ssd.global.jwt.repository.AccessTokenBlacklistRepository;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockFilterChain;
@@ -32,10 +33,13 @@ class JWTFilterTest {
     @Mock
     private CustomUserDetailsService customUserDetailsService;
 
+    @Mock
+    private AccessTokenBlacklistRepository accessTokenBlacklistRepository;
+
     @Test
     @DisplayName("Bearer 스킴이 아닌 Authorization 헤더는 401과 상세 메시지를 반환한다")
     void doFilterInternal_invalidAuthorizationHeader_returnsUnauthorized() throws ServletException, IOException {
-        JWTFilter jwtFilter = new JWTFilter(jwtUtil, jwtConfig, customUserDetailsService);
+        JWTFilter jwtFilter = new JWTFilter(jwtUtil, jwtConfig, customUserDetailsService, accessTokenBlacklistRepository);
         MockHttpServletRequest request = new MockHttpServletRequest();
         MockHttpServletResponse response = new MockHttpServletResponse();
         MockFilterChain filterChain = new MockFilterChain();
@@ -53,7 +57,7 @@ class JWTFilterTest {
     @Test
     @DisplayName("만료된 액세스 토큰은 401과 만료 메시지를 반환한다")
     void doFilterInternal_expiredAccessToken_returnsUnauthorized() throws ServletException, IOException {
-        JWTFilter jwtFilter = new JWTFilter(jwtUtil, jwtConfig, customUserDetailsService);
+        JWTFilter jwtFilter = new JWTFilter(jwtUtil, jwtConfig, customUserDetailsService, accessTokenBlacklistRepository);
         MockHttpServletRequest request = new MockHttpServletRequest();
         MockHttpServletResponse response = new MockHttpServletResponse();
         MockFilterChain filterChain = new MockFilterChain();
@@ -72,7 +76,7 @@ class JWTFilterTest {
     @Test
     @DisplayName("토큰의 회원이 존재하지 않으면 401과 상세 메시지를 반환한다")
     void doFilterInternal_tokenMemberNotFound_returnsUnauthorized() throws ServletException, IOException {
-        JWTFilter jwtFilter = new JWTFilter(jwtUtil, jwtConfig, customUserDetailsService);
+        JWTFilter jwtFilter = new JWTFilter(jwtUtil, jwtConfig, customUserDetailsService, accessTokenBlacklistRepository);
         MockHttpServletRequest request = new MockHttpServletRequest();
         MockHttpServletResponse response = new MockHttpServletResponse();
         MockFilterChain filterChain = new MockFilterChain();
@@ -91,5 +95,27 @@ class JWTFilterTest {
         assertThat(response.getStatus()).isEqualTo(ErrorCode.TOKEN_MEMBER_NOT_FOUND.getStatus().value());
         assertThat(response.getContentAsString()).contains(ErrorCode.TOKEN_MEMBER_NOT_FOUND.getCode());
         assertThat(response.getContentAsString()).contains(ErrorCode.TOKEN_MEMBER_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("블랙리스트에 등록된 액세스 토큰은 401과 상세 메시지를 반환한다")
+    void doFilterInternal_blacklistedAccessToken_returnsUnauthorized() throws ServletException, IOException {
+        JWTFilter jwtFilter = new JWTFilter(jwtUtil, jwtConfig, customUserDetailsService, accessTokenBlacklistRepository);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain filterChain = new MockFilterChain();
+
+        when(jwtConfig.getHeader()).thenReturn("Authorization");
+        request.addHeader("Authorization", "Bearer blacklisted-token");
+        when(jwtUtil.isExpired("blacklisted-token")).thenReturn(false);
+        when(jwtUtil.getCategory("blacklisted-token")).thenReturn("access");
+        when(jwtUtil.getJti("blacklisted-token")).thenReturn("access-jti");
+        when(accessTokenBlacklistRepository.exists("access-jti")).thenReturn(true);
+
+        jwtFilter.doFilterInternal(request, response, filterChain);
+
+        assertThat(response.getStatus()).isEqualTo(ErrorCode.ACCESS_TOKEN_BLACKLISTED.getStatus().value());
+        assertThat(response.getContentAsString()).contains(ErrorCode.ACCESS_TOKEN_BLACKLISTED.getCode());
+        assertThat(response.getContentAsString()).contains(ErrorCode.ACCESS_TOKEN_BLACKLISTED.getMessage());
     }
 }

--- a/ssd-core/src/main/java/or/hyu/ssd/global/api/ErrorCode.java
+++ b/ssd-core/src/main/java/or/hyu/ssd/global/api/ErrorCode.java
@@ -80,6 +80,7 @@ public enum ErrorCode {
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED,"TOKEN40307" ,"유효하지 않은 토큰입니다"),
     ACCESS_TOKEN_REQUIRED(HttpStatus.UNAUTHORIZED,"TOKEN40309" ,"액세스 토큰이 필요합니다"),
     TOKEN_MEMBER_NOT_FOUND(HttpStatus.UNAUTHORIZED,"TOKEN40310" ,"토큰에 해당하는 회원을 찾을 수 없습니다"),
+    ACCESS_TOKEN_BLACKLISTED(HttpStatus.UNAUTHORIZED,"TOKEN40311" ,"로그아웃된 액세스 토큰입니다"),
 
     // 요청 바디/JSON 파싱 예외
     REQUEST_BODY_INVALID_JSON(HttpStatus.BAD_REQUEST, "REQ40001", "요청 본문 JSON 파싱에 실패했습니다. 문자열의 개행은 \\n 로 이스케이프해 주세요"),

--- a/ssd-core/src/main/java/or/hyu/ssd/global/config/RedisConfig.java
+++ b/ssd-core/src/main/java/or/hyu/ssd/global/config/RedisConfig.java
@@ -41,6 +41,20 @@ public class RedisConfig {
         template.setConnectionFactory(connectionFactory);
         template.setKeySerializer(new StringRedisSerializer());
         template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+        return template;
+    }
+
+    @Bean
+    public RedisTemplate<String, String> stringRedisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        StringRedisSerializer stringSerializer = new StringRedisSerializer();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(stringSerializer);
+        template.setValueSerializer(stringSerializer);
+        template.setHashKeySerializer(stringSerializer);
+        template.setHashValueSerializer(stringSerializer);
         return template;
     }
 

--- a/ssd-core/src/main/java/or/hyu/ssd/global/jwt/BearerTokenExtractor.java
+++ b/ssd-core/src/main/java/or/hyu/ssd/global/jwt/BearerTokenExtractor.java
@@ -1,0 +1,22 @@
+package or.hyu.ssd.global.jwt;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import or.hyu.ssd.global.api.ErrorCode;
+import or.hyu.ssd.global.api.handler.TokenHandler;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class BearerTokenExtractor {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    public static String extract(String authorizationHeader) {
+        if (authorizationHeader == null) {
+            throw new TokenHandler(ErrorCode.ACCESS_TOKEN_REQUIRED);
+        }
+        if (!authorizationHeader.startsWith(BEARER_PREFIX)) {
+            throw new TokenHandler(ErrorCode.ACCESS_INVALID_TYPE);
+        }
+        return authorizationHeader.substring(BEARER_PREFIX.length()).trim();
+    }
+}

--- a/ssd-core/src/main/java/or/hyu/ssd/global/jwt/repository/AccessTokenBlacklistRepository.java
+++ b/ssd-core/src/main/java/or/hyu/ssd/global/jwt/repository/AccessTokenBlacklistRepository.java
@@ -1,0 +1,24 @@
+package or.hyu.ssd.global.jwt.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Component
+@RequiredArgsConstructor
+public class AccessTokenBlacklistRepository {
+
+    private static final String PREFIX = "access-blacklist:";
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public boolean exists(String jti) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey(PREFIX + jti));
+    }
+
+    public void save(String jti, long ttlSeconds) {
+        redisTemplate.opsForValue().set(PREFIX + jti, "blacklisted", Duration.ofSeconds(ttlSeconds));
+    }
+}

--- a/ssd-domain/src/main/java/or/hyu/ssd/global/jwt/service/JWTService.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/global/jwt/service/JWTService.java
@@ -5,6 +5,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import or.hyu.ssd.domain.member.entity.Member;
 import or.hyu.ssd.domain.member.repository.MemberRepository;
+import or.hyu.ssd.global.api.handler.TokenHandler;
 import or.hyu.ssd.global.jwt.repository.RefreshTokenRepository;
 import or.hyu.ssd.domain.member.valid.RefreshTokenValidator;
 import or.hyu.ssd.global.api.ErrorCode;
@@ -12,6 +13,7 @@ import or.hyu.ssd.global.api.handler.UserExceptionHandler;
 import or.hyu.ssd.global.config.properties.CookieConfig;
 import or.hyu.ssd.global.config.properties.JWTConfig;
 import or.hyu.ssd.global.jwt.JWTUtil;
+import or.hyu.ssd.global.jwt.repository.AccessTokenBlacklistRepository;
 import or.hyu.ssd.global.util.CookieUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,6 +29,7 @@ public class JWTService {
     private final JWTConfig jwtConfig;
     private final MemberRepository userRepository;
     private final RefreshTokenRepository refreshTokenRedisTemplateUtil;
+    private final AccessTokenBlacklistRepository accessTokenBlacklistRepository;
     private final CookieConfig cookieConfig;
     private final RefreshTokenValidator refreshTokenValidator;
 
@@ -85,7 +88,13 @@ public class JWTService {
 
     }
 
-    public void logout(Long userId, HttpServletResponse response) {
+    public void logout(Long userId, HttpServletRequest request, HttpServletResponse response) {
+        String accessToken = extractAccessToken(request);
+        long remainingExpiration = jwtUtil.getRemainingExpiration(accessToken);
+        if (remainingExpiration > 0) {
+            accessTokenBlacklistRepository.save(jwtUtil.getJti(accessToken), remainingExpiration);
+        }
+
         refreshTokenRedisTemplateUtil.deleteById(userId);
 
         CookieUtil.expireSameSiteCookie(
@@ -95,5 +104,16 @@ public class JWTService {
                 cookieConfig.isSecure(),
                 cookieConfig.getSameSite()
         );
+    }
+
+    private String extractAccessToken(HttpServletRequest request) {
+        String authorizationHeader = request.getHeader(jwtConfig.getHeader());
+        if (authorizationHeader == null) {
+            throw new TokenHandler(ErrorCode.ACCESS_TOKEN_REQUIRED);
+        }
+        if (!authorizationHeader.startsWith("Bearer ")) {
+            throw new TokenHandler(ErrorCode.ACCESS_INVALID_TYPE);
+        }
+        return authorizationHeader.substring(7).trim();
     }
 }

--- a/ssd-domain/src/main/java/or/hyu/ssd/global/jwt/service/JWTService.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/global/jwt/service/JWTService.java
@@ -5,8 +5,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import or.hyu.ssd.domain.member.entity.Member;
 import or.hyu.ssd.domain.member.repository.MemberRepository;
-import or.hyu.ssd.global.api.handler.TokenHandler;
-import or.hyu.ssd.global.jwt.repository.RefreshTokenRepository;
 import or.hyu.ssd.domain.member.valid.RefreshTokenValidator;
 import or.hyu.ssd.global.api.ErrorCode;
 import or.hyu.ssd.global.api.handler.UserExceptionHandler;
@@ -14,17 +12,13 @@ import or.hyu.ssd.global.config.properties.CookieConfig;
 import or.hyu.ssd.global.config.properties.JWTConfig;
 import or.hyu.ssd.global.jwt.JWTUtil;
 import or.hyu.ssd.global.jwt.repository.AccessTokenBlacklistRepository;
+import or.hyu.ssd.global.jwt.repository.RefreshTokenRepository;
 import or.hyu.ssd.global.util.CookieUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class JWTService {
-
-
-    private static final Logger log = LoggerFactory.getLogger(JWTService.class);
     private final JWTUtil jwtUtil;
     private final JWTConfig jwtConfig;
     private final MemberRepository userRepository;
@@ -88,8 +82,7 @@ public class JWTService {
 
     }
 
-    public void logout(Long userId, HttpServletRequest request, HttpServletResponse response) {
-        String accessToken = extractAccessToken(request);
+    public void logout(Long userId, String accessToken, HttpServletResponse response) {
         long remainingExpiration = jwtUtil.getRemainingExpiration(accessToken);
         if (remainingExpiration > 0) {
             accessTokenBlacklistRepository.save(jwtUtil.getJti(accessToken), remainingExpiration);
@@ -104,16 +97,5 @@ public class JWTService {
                 cookieConfig.isSecure(),
                 cookieConfig.getSameSite()
         );
-    }
-
-    private String extractAccessToken(HttpServletRequest request) {
-        String authorizationHeader = request.getHeader(jwtConfig.getHeader());
-        if (authorizationHeader == null) {
-            throw new TokenHandler(ErrorCode.ACCESS_TOKEN_REQUIRED);
-        }
-        if (!authorizationHeader.startsWith("Bearer ")) {
-            throw new TokenHandler(ErrorCode.ACCESS_INVALID_TYPE);
-        }
-        return authorizationHeader.substring(7).trim();
     }
 }

--- a/ssd-domain/src/test/java/or/hyu/ssd/global/jwt/service/JWTServiceTest.java
+++ b/ssd-domain/src/test/java/or/hyu/ssd/global/jwt/service/JWTServiceTest.java
@@ -6,6 +6,7 @@ import or.hyu.ssd.domain.member.valid.RefreshTokenValidator;
 import or.hyu.ssd.global.config.properties.CookieConfig;
 import or.hyu.ssd.global.config.properties.JWTConfig;
 import or.hyu.ssd.global.jwt.JWTUtil;
+import or.hyu.ssd.global.jwt.repository.AccessTokenBlacklistRepository;
 import or.hyu.ssd.global.jwt.repository.RefreshTokenRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -13,10 +14,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -30,6 +33,8 @@ class JWTServiceTest {
     private RefreshTokenRepository refreshTokenRepository;
     @Mock
     private RefreshTokenValidator refreshTokenValidator;
+    @Mock
+    private AccessTokenBlacklistRepository accessTokenBlacklistRepository;
 
     private JWTConfig jwtConfig;
     private CookieConfig cookieConfig;
@@ -38,6 +43,7 @@ class JWTServiceTest {
     @BeforeEach
     void setUp() {
         jwtConfig = new JWTConfig();
+        jwtConfig.setHeader("Authorization");
         jwtConfig.setAccessTokenValidityInSeconds(3600L);
         jwtConfig.setRefreshTokenValidityInSeconds(2592000L);
 
@@ -51,18 +57,25 @@ class JWTServiceTest {
                 jwtConfig,
                 memberRepository,
                 refreshTokenRepository,
+                accessTokenBlacklistRepository,
                 cookieConfig,
                 refreshTokenValidator
         );
     }
 
     @Test
-    @DisplayName("logout()은 Redis refresh token을 삭제하고 refresh-token 쿠키를 만료시킨다")
-    void logout_deletesRefreshTokenAndExpiresCookie() {
+    @DisplayName("logout()은 access token을 블랙리스트에 등록하고 refresh token을 삭제한 뒤 refresh-token 쿠키를 만료시킨다")
+    void logout_blacklistsAccessTokenAndExpiresCookie() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
         MockHttpServletResponse response = new MockHttpServletResponse();
+        request.addHeader("Authorization", "Bearer valid-access-token");
 
-        jwtService.logout(1L, response);
+        when(jwtUtil.getRemainingExpiration("valid-access-token")).thenReturn(1800L);
+        when(jwtUtil.getJti("valid-access-token")).thenReturn("access-jti");
 
+        jwtService.logout(1L, request, response);
+
+        verify(accessTokenBlacklistRepository).save("access-jti", 1800L);
         verify(refreshTokenRepository).deleteById(1L);
         assertThat(response.getHeader("Set-Cookie"))
                 .contains("refresh-token=")

--- a/ssd-domain/src/test/java/or/hyu/ssd/global/jwt/service/JWTServiceTest.java
+++ b/ssd-domain/src/test/java/or/hyu/ssd/global/jwt/service/JWTServiceTest.java
@@ -66,14 +66,12 @@ class JWTServiceTest {
     @Test
     @DisplayName("logout()은 access token을 블랙리스트에 등록하고 refresh token을 삭제한 뒤 refresh-token 쿠키를 만료시킨다")
     void logout_blacklistsAccessTokenAndExpiresCookie() {
-        MockHttpServletRequest request = new MockHttpServletRequest();
         MockHttpServletResponse response = new MockHttpServletResponse();
-        request.addHeader("Authorization", "Bearer valid-access-token");
 
         when(jwtUtil.getRemainingExpiration("valid-access-token")).thenReturn(1800L);
         when(jwtUtil.getJti("valid-access-token")).thenReturn("access-jti");
 
-        jwtService.logout(1L, request, response);
+        jwtService.logout(1L, "valid-access-token", response);
 
         verify(accessTokenBlacklistRepository).save("access-jti", 1800L);
         verify(refreshTokenRepository).deleteById(1L);


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #133


<br><br>

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

### 로그아웃 시, 기존에 남아있던 액세스 토큰으로 인해 접근이 가능해지는 것을 방어하고자 블랙리스트를 구현하였습니다.

<br><br>

## 🙏 Details

<!-- 이번 PR에서 구현한 내용 중 포인트가 되는 부분을 자세하게 적어주세요 -->

### 로그아웃 시, 기존 액세스 토큰을 블랙리스트에 추가하여 재진입하더라도 접근이 불가능하도록 구현하였습니다.

```java
public void logout(Long userId, HttpServletRequest request, HttpServletResponse response) {
        String accessToken = extractAccessToken(request);
        long remainingExpiration = jwtUtil.getRemainingExpiration(accessToken);
        if (remainingExpiration > 0) {
            accessTokenBlacklistRepository.save(jwtUtil.getJti(accessToken), remainingExpiration);
        }
```

이를 위해 jti라는 JWT의 식별자 역할을 하는 필드를 추가하여 구현하였습니다.


### 이는 필터단에서 검증됩니다.
```java
String jti = jwtUtil.getJti(accessToken);
            if (accessTokenBlacklistRepository.exists(jti)) {
                setErrorResponse(response, ErrorCode.ACCESS_TOKEN_BLACKLISTED);
                return;
            }
```




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 로그아웃 시 액세스 토큰을 즉시 블랙리스트에 등록해 즉시 무효화합니다.
* **버그 수정**
  * 블랙리스트된 액세스 토큰으로의 API 접근이 차단되어 요청이 거부됩니다.
* **문서**
  * 로그아웃 API 설명을 즉시 블랙리스트 처리로 갱신했습니다.
* **테스트**
  * 블랙리스트 처리 흐름을 검증하는 자동화 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->