### PR TITLE
[CHORE] 문서 복합 인덱스 추가

### DIFF
--- a/ssd-infra/src/main/java/or/hyu/ssd/infra/persistence/base/BaseJpaEntity.java
+++ b/ssd-infra/src/main/java/or/hyu/ssd/infra/persistence/base/BaseJpaEntity.java
@@ -21,9 +21,10 @@ import java.time.LocalDateTime;
 public abstract class BaseJpaEntity {
 
     @CreatedDate
-    @Column(updatable = false)
+    @Column(name = "created_at", updatable = false)
     protected LocalDateTime createdAt;
 
     @LastModifiedDate
+    @Column(name = "updated_at")
     protected LocalDateTime updatedAt;
 }

--- a/ssd-infra/src/main/java/or/hyu/ssd/infra/persistence/document/entity/DocumentJpaEntity.java
+++ b/ssd-infra/src/main/java/or/hyu/ssd/infra/persistence/document/entity/DocumentJpaEntity.java
@@ -6,6 +6,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -25,7 +26,13 @@ import java.util.Map;
 @Getter
 @SuperBuilder(toBuilder = true)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "documents")
+@Table(
+        name = "documents",
+        indexes = {
+                @Index(name = "idx_documents_member_folder_updated_at", columnList = "member_id, folder_id, updated_at"),
+                @Index(name = "idx_documents_member_title", columnList = "member_id, title")
+        }
+)
 public class DocumentJpaEntity extends BaseJpaEntity {
 
     @Id


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #159 


<br><br>

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

문서 조회 API는 사용자에게 가장 빈도높게 노출되는 API라고 생각하였습니다.

문서 엔티티에 복합 인덱스를 추가하여 문서조회 API 성능을 개선하였습니다.

<br><br>

## 🙏 Details

<!-- 이번 PR에서 구현한 내용 중 포인트가 되는 부분을 자세하게 적어주세요 -->


### 복합 인덱스 추가

아래만큼의 데이터를 적재하여 explain 쿼리를 활용한 데이터 처리 성능을 테스트하였습니다. 기준은 `최신순 조회` 였습니다.
```
members: 10,001
folders: 100,000
documents: 500,002
```

응답은 아래와 같았습니다.
```sql
Gather Merge  (cost=14593.24..14594.17 rows=8 width=56) (actual time=4446.775..4542.167 rows=10 loops=1)
  Workers Planned: 2
  Workers Launched: 2
  Buffers: shared hit=11103
  ->  Sort  (cost=13593.22..13593.23 rows=4 width=56) (actual time=4206.965..4206.970 rows=3 loops=3)
        Sort Key: updated_at DESC
        Sort Method: quicksort  Memory: 25kB
        Buffers: shared hit=11103
        Worker 0:  Sort Method: quicksort  Memory: 25kB
        Worker 1:  Sort Method: quicksort  Memory: 25kB
        ->  Parallel Seq Scan on documents  (cost=0.00..13593.18 rows=4 width=56) (actual time=4034.713..4171.032 rows=3 loops=3)
              Filter: ((folder_id IS NULL) AND (member_id = 2))
              Rows Removed by Filter: 166664
              Buffers: shared hit=10989
Planning:
  Buffers: shared hit=89
Planning Time: 8.959 ms
Execution Time: 4542.237 ms
```

주요 지표는 아래와 같습니다.
- `Parallel Seq Scan on documents`
    - `documents` 테이블 전체를 병렬로 훑고 있다.
    - 필요한 결과는 10건인데, 전체 50만 건을 다 읽는 방향으로 실행됐다.
- `Rows Removed by Filter: 166664`
    - 각 워커가 대부분의 row를 버리고 있다는 뜻이다.
    - 즉, 조건에 맞는 데이터는 극히 일부인데도 전체 탐색이 발생한다.
- `Sort Key: updated_at DESC`
    - 필터링 후 다시 정렬까지 수행하고 있다.
    - 인덱스만으로 정렬을 해결하지 못하고 있다는 뜻이다.
- `Execution Time: 4542.237 ms`
    - 단순 목록 조회인데 4.5초가 걸렸다.
- `Buffers: shared hit=11103`
    - 문서 목록 한 번 조회하는 데 매우 많은 페이지를 읽고 있다.

이를 해결하기 위해서 member_id와 folder_id, 그리고 updated_at 총 세가지 필드를 이용한 복합인덱스를 추가하였습니다.
```java
@Table(
        name = "documents",
        indexes = {
                @Index(name = "idx_documents_member_folder_updated_at", columnList = "member_id, folder_id, updated_at"),
                @Index(name = "idx_documents_member_title", columnList = "member_id, title")
        }
)
```


그 이후 explain의 쿼리 결과입니다.
```sql
Sort  (cost=24.54..24.56 rows=10 width=56) (actual time=0.055..0.056 rows=10 loops=1)
  Sort Key: updated_at DESC
  Sort Method: quicksort  Memory: 25kB
  Buffers: shared hit=10
  ->  Index Scan using idx_documents_member_folder_updated_at on documents  (cost=0.42..24.37 rows=10 width=56) (actual time=0.036..0.039 rows=10 loops=1)
        Index Cond: ((member_id = 2) AND (folder_id IS NULL))
        Buffers: shared hit=7
Planning:
  Buffers: shared hit=152 read=1
Planning Time: 1.439 ms
Execution Time: 0.091 ms
```

조회 성능 개선은 아래와 같이 되었습니다.

<br>

시나리오 | 개선 전 | 개선 후 | 변화
-- | -- | -- | --
루트 문서 최신순 | 4542.237 ms | 0.091 ms | Parallel Seq Scan + Sort -> Index Scan
특정 폴더 최신순 | 4435.699 ms | 0.079 ms | Parallel Seq Scan + Sort -> Index Scan
전체 문서 이름순 | 4430.536 ms | 0.253 ms | Parallel Seq Scan + Sort -> Index Scan


<!-- notionvc: b5a29313-6be2-4e32-99f5-6d8c1a51521c -->

---
<br>

### Projection 도입 X

현재 사용 필드는 매우 적은데 전체 필드를 조회하고 있어, 대용량 데이터 조회시의 로스가 있는 상황입니다.

하지만 이를 해결하기 위해 DTO Projection은 도입하지 않았습니다.
문서조회 API 특성상 세부적인 필드 수정이 잦을 것이라 생각하고 -> 이를 Projection으로 강제화한다면 유지보수 비용이 비교적 커질 것이라고 생각합니다.

이때의 유지보수 비용과 쿼리 성능의 비교에서 유지보수 비용이 클 것으로 판단하여 추가하지 않았습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **성능 개선**
  * 문서 조회 및 필터링 쿼리 성능 향상을 위한 인덱스가 추가되어 응답 속도가 개선됩니다.
* **유지보수 / 리팩터**
  * 생성·수정 타임스탬프의 DB 매핑이 명확히 정리되어 감사 및 시간 기반 정렬/검색의 일관성이 향상됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->