### PR TITLE
[CHORE] 문서 목록 조회 Query N+1 

### DIFF
--- a/ssd-domain/src/main/java/or/hyu/ssd/document/application/service/FolderService.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/document/application/service/FolderService.java
@@ -21,6 +21,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -222,10 +223,17 @@ public class FolderService {
     }
 
     private List<FolderListItemResult> toFolderItems(Long memberId, List<Folder> folders) {
+        Set<Long> folderIdsHavingChildren = folderRepository.findParentIdsHavingChildren(
+                memberId,
+                folders.stream()
+                        .map(Folder::getId)
+                        .toList()
+        );
+
         return folders.stream()
                 .map(folder -> FolderListItemResult.of(
                         folder,
-                        folderRepository.existsByMember_IdAndParent_Id(memberId, folder.getId())
+                        folderIdsHavingChildren.contains(folder.getId())
                 ))
                 .collect(Collectors.toList());
     }

--- a/ssd-domain/src/main/java/or/hyu/ssd/document/repository/FolderRepository.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/document/repository/FolderRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Sort;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface FolderRepository {
 
@@ -21,6 +22,8 @@ public interface FolderRepository {
     List<Folder> findAllByMember_Id(Long memberId, Sort sort);
 
     boolean existsByMember_IdAndParent_Id(Long memberId, Long parentId);
+
+    Set<Long> findParentIdsHavingChildren(Long memberId, List<Long> parentIds);
 
     void delete(Folder folder);
 }

--- a/ssd-domain/src/test/java/or/hyu/ssd/document/application/service/FolderServiceTest.java
+++ b/ssd-domain/src/test/java/or/hyu/ssd/document/application/service/FolderServiceTest.java
@@ -20,6 +20,7 @@ import org.springframework.data.domain.Sort;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -57,8 +58,7 @@ class FolderServiceTest {
         when(folderRepository.findAllByMember_IdAndParentIsNull(1L)).thenReturn(List.of(rootA, rootB));
         when(documentRepository.findAllByMember_IdAndFolderIsNull(any(Long.class), any(Sort.class)))
                 .thenReturn(List.of(rootDoc));
-        when(folderRepository.existsByMember_IdAndParent_Id(1L, 1L)).thenReturn(true);
-        when(folderRepository.existsByMember_IdAndParent_Id(1L, 2L)).thenReturn(false);
+        when(folderRepository.findParentIdsHavingChildren(1L, List.of(1L, 2L))).thenReturn(Set.of(1L));
 
         FolderContentResult result = folderService.listContent(user, null);
 
@@ -86,7 +86,7 @@ class FolderServiceTest {
         when(folderRepository.findAllByMember_IdAndParent_Id(1L, 20L)).thenReturn(List.of(child));
         when(documentRepository.findAllByMember_IdAndFolder_Id(1L, 20L, Sort.by(Sort.Order.desc("updatedAt"))))
                 .thenReturn(List.of(doc));
-        when(folderRepository.existsByMember_IdAndParent_Id(1L, 21L)).thenReturn(false);
+        when(folderRepository.findParentIdsHavingChildren(1L, List.of(21L))).thenReturn(Set.of());
 
         // then
         FolderContentResult result = folderService.listContent(user, 20L);
@@ -115,8 +115,7 @@ class FolderServiceTest {
                 .thenReturn(List.of(root, child));
         when(documentRepository.findAllByMember_Id(any(Long.class), any(Sort.class)))
                 .thenReturn(List.of(docInRoot, docInChild));
-        when(folderRepository.existsByMember_IdAndParent_Id(1L, 1L)).thenReturn(true);
-        when(folderRepository.existsByMember_IdAndParent_Id(1L, 11L)).thenReturn(false);
+        when(folderRepository.findParentIdsHavingChildren(1L, List.of(1L, 11L))).thenReturn(Set.of(1L));
 
         FolderContentResult result = folderService.listAllContent(user);
 

--- a/ssd-infra/build.gradle
+++ b/ssd-infra/build.gradle
@@ -8,7 +8,11 @@ dependencies {
     implementation project(':ssd-external')
 
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
     implementation 'io.github.openfeign:feign-core:13.6'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.1.0:jakarta'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/ssd-infra/src/main/java/or/hyu/ssd/infra/config/JpaConfig.java
+++ b/ssd-infra/src/main/java/or/hyu/ssd/infra/config/JpaConfig.java
@@ -1,9 +1,17 @@
 package or.hyu.ssd.infra.config;
 
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @Configuration
 @EnableJpaAuditing
 public class JpaConfig {
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager entityManager) {
+        return new JPAQueryFactory(entityManager);
+    }
 }

--- a/ssd-infra/src/main/java/or/hyu/ssd/infra/persistence/document/repository/FolderRepositoryImpl.java
+++ b/ssd-infra/src/main/java/or/hyu/ssd/infra/persistence/document/repository/FolderRepositoryImpl.java
@@ -8,8 +8,10 @@ import or.hyu.ssd.infra.persistence.document.repository.jpa.FolderJpaRepository;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @Repository
 @RequiredArgsConstructor
@@ -56,6 +58,14 @@ public class FolderRepositoryImpl implements FolderRepository {
     @Override
     public boolean existsByMember_IdAndParent_Id(Long memberId, Long parentId) {
         return folderJpaRepository.existsByMember_IdAndParent_Id(memberId, parentId);
+    }
+
+    @Override
+    public Set<Long> findParentIdsHavingChildren(Long memberId, List<Long> parentIds) {
+        if (parentIds == null || parentIds.isEmpty()) {
+            return Set.of();
+        }
+        return new LinkedHashSet<>(folderJpaRepository.findDistinctParentIdsByMember_IdAndParent_IdIn(memberId, parentIds));
     }
 
     @Override

--- a/ssd-infra/src/main/java/or/hyu/ssd/infra/persistence/document/repository/FolderRepositoryImpl.java
+++ b/ssd-infra/src/main/java/or/hyu/ssd/infra/persistence/document/repository/FolderRepositoryImpl.java
@@ -1,8 +1,10 @@
 package or.hyu.ssd.infra.persistence.document.repository;
 
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import or.hyu.ssd.document.domain.model.Folder;
 import or.hyu.ssd.document.repository.FolderRepository;
+import or.hyu.ssd.infra.persistence.document.entity.QFolderJpaEntity;
 import or.hyu.ssd.infra.persistence.document.mapper.DocumentPersistenceMapper;
 import or.hyu.ssd.infra.persistence.document.repository.jpa.FolderJpaRepository;
 import org.springframework.data.domain.Sort;
@@ -18,6 +20,7 @@ import java.util.Set;
 public class FolderRepositoryImpl implements FolderRepository {
 
     private final FolderJpaRepository folderJpaRepository;
+    private final JPAQueryFactory queryFactory;
 
     @Override
     public Folder save(Folder folder) {
@@ -65,7 +68,17 @@ public class FolderRepositoryImpl implements FolderRepository {
         if (parentIds == null || parentIds.isEmpty()) {
             return Set.of();
         }
-        return new LinkedHashSet<>(folderJpaRepository.findDistinctParentIdsByMember_IdAndParent_IdIn(memberId, parentIds));
+
+        QFolderJpaEntity child = new QFolderJpaEntity("child");
+        return new LinkedHashSet<>(queryFactory
+                .select(child.parent.id)
+                .distinct()
+                .from(child)
+                .where(
+                        child.member.id.eq(memberId),
+                        child.parent.id.in(parentIds)
+                )
+                .fetch());
     }
 
     @Override

--- a/ssd-infra/src/main/java/or/hyu/ssd/infra/persistence/document/repository/jpa/FolderJpaRepository.java
+++ b/ssd-infra/src/main/java/or/hyu/ssd/infra/persistence/document/repository/jpa/FolderJpaRepository.java
@@ -3,6 +3,7 @@ package or.hyu.ssd.infra.persistence.document.repository.jpa;
 import or.hyu.ssd.infra.persistence.document.entity.FolderJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -17,4 +18,12 @@ public interface FolderJpaRepository extends JpaRepository<FolderJpaEntity, Long
     List<FolderJpaEntity> findAllByMember_Id(Long memberId, Sort sort);
 
     boolean existsByMember_IdAndParent_Id(Long memberId, Long parentId);
+
+    @Query("""
+            select distinct child.parent.id
+            from FolderJpaEntity child
+            where child.member.id = :memberId
+              and child.parent.id in :parentIds
+            """)
+    List<Long> findDistinctParentIdsByMember_IdAndParent_IdIn(Long memberId, List<Long> parentIds);
 }

--- a/ssd-infra/src/main/java/or/hyu/ssd/infra/persistence/document/repository/jpa/FolderJpaRepository.java
+++ b/ssd-infra/src/main/java/or/hyu/ssd/infra/persistence/document/repository/jpa/FolderJpaRepository.java
@@ -1,9 +1,8 @@
 package or.hyu.ssd.infra.persistence.document.repository.jpa;
 
 import or.hyu.ssd.infra.persistence.document.entity.FolderJpaEntity;
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 import java.util.Optional;
@@ -18,12 +17,4 @@ public interface FolderJpaRepository extends JpaRepository<FolderJpaEntity, Long
     List<FolderJpaEntity> findAllByMember_Id(Long memberId, Sort sort);
 
     boolean existsByMember_IdAndParent_Id(Long memberId, Long parentId);
-
-    @Query("""
-            select distinct child.parent.id
-            from FolderJpaEntity child
-            where child.member.id = :memberId
-              and child.parent.id in :parentIds
-            """)
-    List<Long> findDistinctParentIdsByMember_IdAndParent_IdIn(Long memberId, List<Long> parentIds);
 }


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #160 


<br><br>

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

문서 목록조회 내부에서 사용되는 헬퍼 메서드 속의 쿼리가 자식 엔티티 조회를 위한 exist 쿼리를 연쇄적으로 호출하여 N+1개의 쿼리가 발생하는 문제를 해결하였습니다.


<br><br>

## 🙏 Details

<!-- 이번 PR에서 구현한 내용 중 포인트가 되는 부분을 자세하게 적어주세요 -->

기존 코드는 아래와 같았습니다.

```java
private List<FolderListItemResult> toFolderItems(Long memberId, List<Folder> folders) {
    return folders.stream()
            .map(folder -> FolderListItemResult.of(
                    folder,
                    folderRepository.existsByMember_IdAndParent_Id(memberId, folder.getId())
            ))
            .collect(Collectors.toList());
}
```
여기서 `existsByMember_IdAndParent_Id(memberId, folder.getId())` 해당 쿼리 메서드를 실제 쿼리로 치환하면 아래와 같은 쿼리로 치환됩니다.

```sql
SELECT EXISTS (
  SELECT 1
  FROM folders
  WHERE member_id = ?
    AND parent_id = ?
);
```

그럼 만약, 폴더가 4개가 존재한다면 아래와 같은 쿼리가 추가적으로 발생합니다.

```sql
SELECT EXISTS (
  SELECT 1
  FROM folders
  WHERE member_id = 2
    AND parent_id = 10
);

SELECT EXISTS (
  SELECT 1
  FROM folders
  WHERE member_id = 2
    AND parent_id = 20
);

SELECT EXISTS (
  SELECT 1
  FROM folders
  WHERE member_id = 2
    AND parent_id = 30
);

SELECT EXISTS (
  SELECT 1
  FROM folders
  WHERE member_id = 2
    AND parent_id = 40
);
```

결론적으로 폴더의 갯수 조회 1회 + 각 폴더마다의 exist 쿼리가 발생하는 구조였습니다.

---

<br>

이는 일반적인 지연로딩으로 인한 N+1과는 다른 문제였습니다. 비즈니스 로직적으로 해결 할 수 있는 부분이 있었습니다.
이를 해결한 방법은 다음과 같아요.

```java
private List<FolderListItemResult> toFolderItems(Long memberId, List<Folder> folders) {
    Set<Long> folderIdsHavingChildren = folderRepository.findParentIdsHavingChildren(
            memberId,
            folders.stream()
                    .map(Folder::getId)
                    .toList()
    );

    return folders.stream()
            .map(folder -> FolderListItemResult.of(
                    folder,
                    folderIdsHavingChildren.contains(folder.getId())
            ))
            .collect(Collectors.toList());
}
```

응답에 사용되는 폴더 ID를 Set자료구조에 별도의 쿼리로 모아놓고, IN을 활용하여 한 방의 쿼리로 자식폴더의 존재를 조회하는 방식으로 로직을 개선했습니다.
최종적으로는 아래와 같은 쿼리 한 번으로 기존의 N번의 쿼리를 예방합니다.

```sql
SELECT DISTINCT parent_id
FROM folders
WHERE member_id = 2
  AND parent_id IN (10, 20, 30, 40);
```
---

<br>

당연하게도 쿼리 하나의 비용은 이전보다 올라갔습니다. (exist 쿼리와 IN 조건절이 들어간 쿼리의 비용차이)
explain 쿼리를 통해 비교해보면 아래와 같은 차이가 있죠.

```sql
Index Scan using idx_folder_parent_id on folders
Filter: (member_id = 2)
Execution Time: 0.299 ms
```

```sql
Hash Join
-> Index Scan using idx_folder_member_id on folders child
-> Index Scan using idx_folder_member_id on folders
Execution Time: 1.095 ms
```

약 4배의 차이가 존재하는데요. 전체로 보았을때의 개선은 훨씬 유의미합니다.
폴더가 500개 있을 경우 아래와 같은 성능 향상이 있었습니다.

항목 | 기존 | 개선
-- | -- | --
루트 폴더 수 | 502 | 502
총 쿼리 수 | 503 | 2
자식 확인 단계 시간 | 4.480 ms | 1.217 ms
쿼리 감소율 | - | 약 99.6% 감소


<!-- notionvc: d87d72a6-fc01-425c-81ad-e94d438d60c1 -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **성능 개선**
  * 폴더 목록 조회 시 데이터베이스 쿼리 효율성 개선 - 개별 폴더 검사 대신 일괄 사전계산 방식으로 전환

* **리팩토링**
  * 데이터베이스 쿼리 인프라 강화 - QueryDSL 지원 추가로 더욱 안정적이고 유연한 데이터 조회 지원

<!-- end of auto-generated comment: release notes by coderabbit.ai -->