### PR TITLE
[FIX] 도메인repository flush 메서드 명시적 추가

### DIFF
--- a/ssd-domain/src/main/java/or/hyu/ssd/document/application/service/DocumentCommandService.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/document/application/service/DocumentCommandService.java
@@ -118,6 +118,7 @@ public class DocumentCommandService {
             createdBlockCount = blockChangeSummary.createdBlockCount();
         }
         saveDocumentLog(document, member, deletedBlockCount, createdBlockCount);
+        documentRepository.save(document);
 
         return UpdateDocumentResult.of(document.getId());
     }
@@ -143,6 +144,7 @@ public class DocumentCommandService {
 
             boolean newValue = !document.isBookmark();
             document.updateIfPresent(null, null, null, null, newValue);
+            documentRepository.save(document);
             documentRepository.flush();
             return DocumentBookmarkResult.of(document.getId(), document.isBookmark());
         });

--- a/ssd-domain/src/main/java/or/hyu/ssd/document/application/service/ExternalAiPersistenceService.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/document/application/service/ExternalAiPersistenceService.java
@@ -62,6 +62,7 @@ public class ExternalAiPersistenceService {
                 teamComposition,
                 doc.getExternalChecklistSnapshot()
         ));
+        documentRepository.save(doc);
         return ExternalAiEvaluationCardResult.of(
                 doc.getId(),
                 doc.getExternalAiTotalScore(),
@@ -77,12 +78,14 @@ public class ExternalAiPersistenceService {
     public ExternalAiSummaryResult saveSummary(Long documentId, String summary, String shortSummary) {
         Document doc = getDocument(documentId);
         doc.updateSummary(summary, shortSummary);
+        documentRepository.save(doc);
         return ExternalAiSummaryResult.of(doc.getId(), doc.getSummary(), doc.getShortSummary());
     }
 
     public ExternalAiKeywordResult saveKeyword(Long documentId, String keyword) {
         Document doc = getDocument(documentId);
         doc.updateKeywords(keyword);
+        documentRepository.save(doc);
         return ExternalAiKeywordResult.of(doc.getId(), doc.getKeywords());
     }
 
@@ -95,6 +98,7 @@ public class ExternalAiPersistenceService {
         Document doc = getDocument(documentId);
         doc.mergeExternalChecklist(checkList);
         refreshAiCheckSnapshots(doc, currentParagraphs);
+        documentRepository.save(doc);
         return ExternalAiDocumentCheckResult.of(doc.getId(), changedBlockIds, doc.getExternalChecklistSnapshot());
     }
 

--- a/ssd-domain/src/main/java/or/hyu/ssd/document/application/service/FolderService.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/document/application/service/FolderService.java
@@ -66,6 +66,8 @@ public class FolderService {
             }
         }
 
+        folderRepository.save(folder);
+
         return UpdateFolderResult.of(folder.getId());
     }
 


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #166 


<br><br>

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

도메인과 JPA가 분리됨에 따라 DirtyCheck를 사용 할 수 없는 문제가 존재했습니다.
이를 해결하기 위해 각 로직에 save() 메서드를 명시적으로 호출하여 db에 정상 반영될 수 있도록 로직을 수정하였습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

- 문서 업데이트 및 북마크 시 모든 변경사항이 데이터베이스에 올바르게 저장됩니다.
- 폴더의 이름, 색상, 계층 구조 변경 시 수정사항이 안정적으로 저장됩니다.
- AI 관련 평가, 요약, 키워드 데이터 변경 시 정보가 확실히 보존됩니다.
- 체크리스트 병합 작업 시 모든 변경사항이 정확하게 저장됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->