### PR TITLE
fix: develop cd 리소스 전송 안정화

### DIFF
--- a/.github/workflows/develop-cd.yml
+++ b/.github/workflows/develop-cd.yml
@@ -88,6 +88,18 @@ jobs:
           cache-from: type=gha,scope=develop-cd-docker
           cache-to: type=gha,mode=max,scope=develop-cd-docker
 
+      - name: 원격 배포 임시 경로 정리
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.HOST }}
+          port: ${{ env.SSH_PORT }}
+          username: ubuntu
+          key: ${{ secrets.KEY }}
+          script_stop: true
+          script: |
+            sudo rm -rf /tmp/deploy /tmp/k6 /tmp/monitoring /tmp/.runtime /tmp/application-dev.yml
+            mkdir -p /tmp
+
       - name: 배포 리소스 전송
         uses: appleboy/scp-action@v0.1.7
         with:
@@ -97,6 +109,7 @@ jobs:
           key: ${{ secrets.KEY }}
           source: "deploy/ec2,k6/monitoring,.runtime/application-dev.yml"
           target: /tmp
+          overwrite: true
 
       - name: EC2 Blue/Green 배포
         uses: appleboy/ssh-action@v1.0.3


### PR DESCRIPTION
## Summary
- 배포 전 원격 /tmp 하위 임시 경로를 정리하도록 추가
- scp 전송 시 overwrite를 켜서 stale 파일 충돌을 방지

## Why
- develop-cd가 `배포 리소스 전송` 단계에서 연속 실패함
- 전송 대상 크기는 매우 작아 용량 이슈 가능성은 낮고, `/tmp` 잔존 파일 충돌 가능성이 높았음
- #167, #168 모두 같은 단계에서 실패해 코드 변경과 무관한 CD 경로 이슈로 판단함

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* **Chores**
  * 배포 인프라를 최적화하여 배포 프로세스의 안정성이 강화되었습니다. 이전 배포 자산을 정리하고 새로운 리소스를 더욱 안전하게 전송할 수 있도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->