### PR TITLE
[FIX] 문서 전체 조회 시, 응답 스펙에 즐겨찾기 추가

### DIFF
--- a/ssd-api/src/main/java/or/hyu/ssd/api/document/controller/DocumentController.java
+++ b/ssd-api/src/main/java/or/hyu/ssd/api/document/controller/DocumentController.java
@@ -281,6 +281,7 @@ public class DocumentController {
                       - purpose: 문서 목적 (`WRITING`, `EVALUATION`)
                       - folderId: 폴더 ID (없으면 루트)
                       - updatedAt: 마지막 수정 시각
+                      - bookmark: 즐겨찾기 여부
 
                     ### 오류
                     - MEMBER_NOT_FOUND: 인증 정보 없음/회원 없음

--- a/ssd-api/src/main/java/or/hyu/ssd/api/document/controller/FolderController.java
+++ b/ssd-api/src/main/java/or/hyu/ssd/api/document/controller/FolderController.java
@@ -140,6 +140,7 @@ public class FolderController {
                       - currentFolderId: 현재 조회 중인 폴더 ID (루트는 0)
                       - folders[]: 하위 폴더 목록
                       - documents[]: 해당 폴더 내부 문서 목록
+                        - bookmark: 문서 즐겨찾기 여부
                     """
     )
     public ResponseEntity<ApiResponse<FolderContentResponse>> listFolders(
@@ -169,6 +170,7 @@ public class FolderController {
                       - currentFolderId: 0 (루트 기준)
                       - folders[]: 전체 폴더 목록
                       - documents[]: 전체 문서 목록
+                        - bookmark: 문서 즐겨찾기 여부
                     """
     )
     public ResponseEntity<ApiResponse<FolderContentResponse>> listAllPaths(

--- a/ssd-api/src/main/java/or/hyu/ssd/api/document/response/DocumentListItemResponse.java
+++ b/ssd-api/src/main/java/or/hyu/ssd/api/document/response/DocumentListItemResponse.java
@@ -10,7 +10,8 @@ public record DocumentListItemResponse(
         String title,
         DocumentPurpose purpose,
         Long folderId,
-        LocalDateTime updatedAt
+        LocalDateTime updatedAt,
+        boolean bookmark
 ) {
     public static DocumentListItemResponse from(DocumentListItemResult result) {
         return new DocumentListItemResponse(
@@ -18,7 +19,8 @@ public record DocumentListItemResponse(
                 result.title(),
                 result.purpose(),
                 result.folderId(),
-                result.updatedAt()
+                result.updatedAt(),
+                result.bookmark()
         );
     }
 }

--- a/ssd-domain/src/main/java/or/hyu/ssd/document/application/result/DocumentListItemResult.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/document/application/result/DocumentListItemResult.java
@@ -10,7 +10,8 @@ public record DocumentListItemResult(
         String title,
         DocumentPurpose purpose,
         Long folderId,
-        LocalDateTime updatedAt
+        LocalDateTime updatedAt,
+        boolean bookmark
 ) {
     public static DocumentListItemResult of(Document doc) {
         return new DocumentListItemResult(
@@ -18,7 +19,8 @@ public record DocumentListItemResult(
                 doc.getTitle(),
                 doc.getPurposeOrDefault(),
                 doc.getFolder() != null ? doc.getFolder().getId() : null,
-                doc.getUpdatedAt()
+                doc.getUpdatedAt(),
+                doc.isBookmark()
         );
     }
 }

--- a/ssd-domain/src/test/java/or/hyu/ssd/document/application/service/DocumentQueryServiceTest.java
+++ b/ssd-domain/src/test/java/or/hyu/ssd/document/application/service/DocumentQueryServiceTest.java
@@ -72,7 +72,7 @@ class DocumentQueryServiceTest {
         // given
         Member member = member(1L);
         Long user = member.getId();
-        Document rootDocument = document(100L, "루트 문서", null, member);
+        Document rootDocument = document(100L, "루트 문서", null, member, true);
 
         // when
         when(documentRepository.findAllByMember_IdAndFolderIsNull(1L, Sort.by(Sort.Order.desc("createdAt"))))
@@ -85,15 +85,20 @@ class DocumentQueryServiceTest {
         assertThat(results.get(0).id()).isEqualTo(100L);
         assertThat(results.get(0).purpose()).isEqualTo(DocumentPurpose.EVALUATION);
         assertThat(results.get(0).folderId()).isNull();
+        assertThat(results.get(0).bookmark()).isTrue();
     }
 
     private Document document(Long id, String title, Folder folder, Member member) {
+        return document(id, title, folder, member, false);
+    }
+
+    private Document document(Long id, String title, Folder folder, Member member, boolean bookmark) {
         return Document.builder()
                 .id(id)
                 .title(title)
                 .content("content")
                 .folder(folder)
-                .bookmark(false)
+                .bookmark(bookmark)
                 .purpose(DocumentPurpose.EVALUATION)
                 .member(member)
                 .build();

--- a/ssd-domain/src/test/java/or/hyu/ssd/document/application/service/FolderServiceTest.java
+++ b/ssd-domain/src/test/java/or/hyu/ssd/document/application/service/FolderServiceTest.java
@@ -107,7 +107,7 @@ class FolderServiceTest {
         // when
         Folder root = folder(1L, "작성하기", null, member);
         Folder child = folder(11L, "1분기 계획서", root, member);
-        Document docInRoot = document(101L, "사업계획서_v1.pdf", root, member);
+        Document docInRoot = document(101L, "사업계획서_v1.pdf", root, member, true);
         Document docInChild = document(102L, "사업계획서_v2_최종.pdf", child, member);
 
         // then
@@ -127,6 +127,8 @@ class FolderServiceTest {
         assertThat(result.folders().get(1).parentId()).isEqualTo(1L);
         assertThat(result.documents().get(0).folderId()).isEqualTo(1L);
         assertThat(result.documents().get(1).folderId()).isEqualTo(11L);
+        assertThat(result.documents().get(0).bookmark()).isTrue();
+        assertThat(result.documents().get(1).bookmark()).isFalse();
     }
 
     @Test
@@ -205,12 +207,16 @@ class FolderServiceTest {
     }
 
     private Document document(Long id, String title, Folder folder, Member member) {
+        return document(id, title, folder, member, false);
+    }
+
+    private Document document(Long id, String title, Folder folder, Member member, boolean bookmark) {
         return Document.builder()
                 .id(id)
                 .title(title)
                 .content("content")
                 .folder(folder)
-                .bookmark(false)
+                .bookmark(bookmark)
                 .member(member)
                 .build();
     }


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #178 


<br><br>

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

문서 전체 조회 시, 응답 스펙에 즐겨찾기 필드를 추가하였습니다.

