### PR TITLE
[FIX] 부하테스트 모니터링 컨테이너 중지 및 GC 설정 튜닝

### DIFF
--- a/.github/workflows/develop-cd.yml
+++ b/.github/workflows/develop-cd.yml
@@ -142,6 +142,8 @@ jobs:
             export NETWORK_NAME="ssd-net"
             export NGINX_SERVER_NAME="dev-api.simsaimdang.shop"
             export NGINX_UPSTREAM_FILE="/etc/nginx/conf.d/ssd-upstream.conf"
+            export APP_LOG_DIR="/opt/ssd/logs"
+            export APP_JAVA_TOOL_OPTIONS="-Xms256m -Xmx256m -Xlog:gc*,safepoint:file=/logs/gc.log:time,uptime,level,tags:filecount=5,filesize=10M"
             sudo -E "${DEPLOY_ROOT}/deploy/ec2/install_infra.sh"
             sudo -E "${DEPLOY_ROOT}/deploy/ec2/install_prod_monitoring.sh"
             sudo -E "${DEPLOY_ROOT}/deploy/ec2/blue_green_deploy.sh"

--- a/deploy/ec2/README.md
+++ b/deploy/ec2/README.md
@@ -7,7 +7,8 @@
 - `nginx/site.conf.template`: dev 도메인 프록시 설정 템플릿
 - `nginx/zzz-ssd-timeout.conf`: 장시간 AI 요청용 timeout 설정
 - `install_infra.sh`: 서버에 정적 인프라 파일을 설치하고 redis를 기동
-- `install_monitoring.sh`: Grafana/Prometheus/load-test 모니터링 스택 설치
+- `install_prod_monitoring.sh`: 운영용 Grafana/Prometheus/Alertmanager 모니터링 스택 설치
+- `install_monitoring.sh`: 부하테스트용 Grafana/Prometheus/k6 모니터링 스택 설치
 - `blue_green_deploy.sh`: blue/green 무중단 배포 스크립트
 
 ## 민감 정보 분리
@@ -16,9 +17,20 @@
 - 애플리케이션 컨테이너는 외부 설정 파일을 `/config/application-dev.yml`로 마운트해 사용합니다.
 
 ## 모니터링 설정
-- 모니터링 리소스는 `k6/monitoring`에 형상관리합니다.
-- `develop-cd`는 서버 `/opt/ssd/monitoring`에 해당 파일을 설치하고 docker compose로 Grafana/Prometheus를 기동합니다.
-- 기본 접속 포트:
-  - Grafana: `3000`
-  - Prometheus: `9090`
-  - k6 Web Dashboard: `5665`
+- 운영 모니터링 리소스는 `deploy/ec2/monitoring`에 형상관리합니다.
+- `develop-cd`는 서버 `/opt/ssd/monitoring-prod`에 해당 파일을 설치하고 docker compose로 Grafana/Prometheus/Alertmanager를 기동합니다.
+- 운영 모니터링은 SSH 터널링 기준으로 접근합니다.
+  - Grafana: `3001`
+  - Prometheus: `9091`
+  - Alertmanager: `9093`
+- 부하테스트용 모니터링 리소스는 `k6/monitoring`에 형상관리합니다.
+- 부하테스트용 모니터링은 평시 서버 RAM 절약을 위해 기본적으로 기동하지 않습니다.
+- 부하테스트 모니터링이 필요할 때만 `LOADTEST_MONITORING_ENABLED=true`로 `install_monitoring.sh`를 실행합니다.
+
+## JVM/GC 설정
+- dev 애플리케이션 컨테이너는 기본적으로 아래 JVM 옵션으로 실행됩니다.
+  - `-Xms256m`
+  - `-Xmx256m`
+  - `-Xlog:gc*,safepoint:file=/logs/gc.log:time,uptime,level,tags:filecount=5,filesize=10M`
+- 호스트의 GC 로그 위치는 `/opt/ssd/logs/gc.log*`입니다.
+- 필요하면 CD 실행 환경에서 `APP_JAVA_TOOL_OPTIONS`와 `APP_LOG_DIR`로 값을 덮어쓸 수 있습니다.

--- a/deploy/ec2/blue_green_deploy.sh
+++ b/deploy/ec2/blue_green_deploy.sh
@@ -17,6 +17,8 @@ NETWORK_NAME="${NETWORK_NAME:-ssd-net}"
 APP_CONFIG_FILE="${APP_CONFIG_FILE:-/opt/${APP_NAME}/config/application-dev.yml}"
 SPRING_CONFIG_ADDITIONAL_LOCATION="${SPRING_CONFIG_ADDITIONAL_LOCATION:-optional:file:/config/}"
 TIME_ZONE="${APP_TIME_ZONE:-Asia/Seoul}"
+APP_LOG_DIR="${APP_LOG_DIR:-/opt/${APP_NAME}/logs}"
+APP_JAVA_TOOL_OPTIONS="${APP_JAVA_TOOL_OPTIONS:--Xms256m -Xmx256m -Xlog:gc*,safepoint:file=/logs/gc.log:time,uptime,level,tags:filecount=5,filesize=10M}"
 
 BLUE_PORT="${BLUE_PORT:-8080}"
 GREEN_PORT="${GREEN_PORT:-8081}"
@@ -29,7 +31,7 @@ HEALTH_RETRY_SLEEP_SECONDS="${HEALTH_RETRY_SLEEP_SECONDS:-2}"
 
 NGINX_UPSTREAM_FILE="${NGINX_UPSTREAM_FILE:-/etc/nginx/conf.d/ssd-upstream.conf}"
 
-mkdir -p "$(dirname "${STATE_FILE}")"
+mkdir -p "$(dirname "${STATE_FILE}")" "${APP_LOG_DIR}"
 
 if [[ ! -f "${APP_CONFIG_FILE}" ]]; then
   echo "[ERROR] application config not found: ${APP_CONFIG_FILE}" >&2
@@ -58,6 +60,7 @@ LEGACY_APP_CONTAINER_NAME="${LEGACY_APP_CONTAINER_NAME:-infra-app-1}"
 
 echo "[INFO] Current=${CURRENT_COLOR}(${CURRENT_PORT}), Next=${NEXT_COLOR}(${NEXT_PORT})"
 echo "[INFO] Pull image: ${IMAGE}"
+echo "[INFO] JAVA_TOOL_OPTIONS=${APP_JAVA_TOOL_OPTIONS}"
 docker pull "${IMAGE}"
 
 docker network inspect "${NETWORK_NAME}" >/dev/null 2>&1 || docker network create "${NETWORK_NAME}"
@@ -71,8 +74,10 @@ docker run -d \
   --network "${NETWORK_NAME}" \
   -e SPRING_PROFILES_ACTIVE="${SPRING_PROFILE}" \
   -e SPRING_CONFIG_ADDITIONAL_LOCATION="${SPRING_CONFIG_ADDITIONAL_LOCATION}" \
+  -e JAVA_TOOL_OPTIONS="${APP_JAVA_TOOL_OPTIONS}" \
   -e TZ="${TIME_ZONE}" \
   -v "${APP_CONFIG_FILE}:/config/application-dev.yml:ro" \
+  -v "${APP_LOG_DIR}:/logs" \
   -p "127.0.0.1:${NEXT_PORT}:${APP_PORT}" \
   "${IMAGE}"
 

--- a/deploy/ec2/install_monitoring.sh
+++ b/deploy/ec2/install_monitoring.sh
@@ -29,7 +29,10 @@ container_running() {
 }
 
 is_enabled() {
-  case "${1,,}" in
+  local normalized
+  normalized="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
+
+  case "${normalized}" in
     true|1|yes|y|on)
       return 0
       ;;
@@ -41,6 +44,33 @@ is_enabled() {
       exit 1
       ;;
   esac
+}
+
+stop_loadtest_monitoring() {
+  if command -v docker >/dev/null 2>&1; then
+    docker compose -f "${MONITORING_COMPOSE_FILE}" down --remove-orphans >/dev/null 2>&1 || true
+  else
+    echo "[WARN] docker is not installed, skip compose down"
+  fi
+}
+
+sync_ufw_rules() {
+  if ! command -v ufw >/dev/null 2>&1; then
+    return
+  fi
+  if ! ufw status | grep -q "Status: active"; then
+    return
+  fi
+
+  if is_enabled "${LOADTEST_MONITORING_ENABLED}"; then
+    ufw allow "${GRAFANA_PORT}/tcp" >/dev/null 2>&1 || true
+    ufw allow "${PROMETHEUS_PORT}/tcp" >/dev/null 2>&1 || true
+    ufw allow "${K6_DASHBOARD_PORT}/tcp" >/dev/null 2>&1 || true
+  else
+    ufw --force delete allow "${GRAFANA_PORT}/tcp" >/dev/null 2>&1 || true
+    ufw --force delete allow "${PROMETHEUS_PORT}/tcp" >/dev/null 2>&1 || true
+    ufw --force delete allow "${K6_DASHBOARD_PORT}/tcp" >/dev/null 2>&1 || true
+  fi
 }
 
 resolve_monitoring_source_dir() {
@@ -65,6 +95,15 @@ resolve_monitoring_source_dir() {
 
   return 1
 }
+
+if ! is_enabled "${LOADTEST_MONITORING_ENABLED}"; then
+  echo "[INFO] Loadtest monitoring disabled, stop containers if they exist"
+  stop_loadtest_monitoring
+  sync_ufw_rules
+  echo "[INFO] Loadtest monitoring is disabled"
+  echo "[INFO] Set LOADTEST_MONITORING_ENABLED=true to start it"
+  exit 0
+fi
 
 MONITORING_SOURCE_DIR="$(resolve_monitoring_source_dir || true)"
 if [[ -z "${MONITORING_SOURCE_DIR}" ]]; then
@@ -101,39 +140,23 @@ while IFS= read -r -d '' dashboard_file; do
 done < <(find "${MONITORING_SOURCE_DIR}/grafana/dashboards" -maxdepth 1 -type f -name '*.json' -print0)
 
 if command -v docker >/dev/null 2>&1; then
-  if is_enabled "${LOADTEST_MONITORING_ENABLED}"; then
-    if (( monitoring_changed == 1 )) \
-      || ! container_running "ssd-loadtest-prometheus" \
-      || ! container_running "ssd-loadtest-grafana" \
-      || ! container_running "ssd-loadtest-node-exporter" \
-      || ! container_running "ssd-loadtest-cadvisor"; then
-      docker compose -f "${MONITORING_COMPOSE_FILE}" up -d
-    else
-      echo "[INFO] Loadtest monitoring unchanged, skip compose up"
-    fi
+  if (( monitoring_changed == 1 )) \
+    || ! container_running "ssd-loadtest-prometheus" \
+    || ! container_running "ssd-loadtest-grafana" \
+    || ! container_running "ssd-loadtest-node-exporter" \
+    || ! container_running "ssd-loadtest-cadvisor"; then
+    docker compose -f "${MONITORING_COMPOSE_FILE}" up -d
   else
-    echo "[INFO] Loadtest monitoring disabled, stop containers if they exist"
-    docker compose -f "${MONITORING_COMPOSE_FILE}" down --remove-orphans >/dev/null 2>&1 || true
+    echo "[INFO] Loadtest monitoring unchanged, skip compose up"
   fi
 else
   echo "[ERROR] docker is not installed" >&2
   exit 1
 fi
 
-if is_enabled "${LOADTEST_MONITORING_ENABLED}" && command -v ufw >/dev/null 2>&1; then
-  if ufw status | grep -q "Status: active"; then
-    ufw allow "${GRAFANA_PORT}/tcp" >/dev/null 2>&1 || true
-    ufw allow "${PROMETHEUS_PORT}/tcp" >/dev/null 2>&1 || true
-    ufw allow "${K6_DASHBOARD_PORT}/tcp" >/dev/null 2>&1 || true
-  fi
-fi
+sync_ufw_rules
 
-if is_enabled "${LOADTEST_MONITORING_ENABLED}"; then
-  echo "[INFO] Loadtest monitoring install complete"
-  echo "[INFO] Grafana:    http://<server>:${GRAFANA_PORT}"
-  echo "[INFO] Prometheus: http://<server>:${PROMETHEUS_PORT}"
-  echo "[INFO] k6 Web UI:  http://<server>:${K6_DASHBOARD_PORT}"
-else
-  echo "[INFO] Loadtest monitoring is disabled"
-  echo "[INFO] Set LOADTEST_MONITORING_ENABLED=true to start it"
-fi
+echo "[INFO] Loadtest monitoring install complete"
+echo "[INFO] Grafana:    http://<server>:${GRAFANA_PORT}"
+echo "[INFO] Prometheus: http://<server>:${PROMETHEUS_PORT}"
+echo "[INFO] k6 Web UI:  http://<server>:${K6_DASHBOARD_PORT}"

--- a/deploy/ec2/install_monitoring.sh
+++ b/deploy/ec2/install_monitoring.sh
@@ -8,6 +8,7 @@ MONITORING_COMPOSE_FILE="${MONITORING_ROOT}/docker-compose.monitoring.yml"
 GRAFANA_PORT="${GRAFANA_PORT:-3000}"
 PROMETHEUS_PORT="${PROMETHEUS_PORT:-9090}"
 K6_DASHBOARD_PORT="${K6_DASHBOARD_PORT:-5665}"
+LOADTEST_MONITORING_ENABLED="${LOADTEST_MONITORING_ENABLED:-false}"
 
 copy_if_changed() {
   local source_file="$1"
@@ -25,6 +26,21 @@ copy_if_changed() {
 container_running() {
   local container_name="$1"
   [[ "$(docker inspect -f '{{.State.Running}}' "${container_name}" 2>/dev/null || true)" == "true" ]]
+}
+
+is_enabled() {
+  case "${1,,}" in
+    true|1|yes|y|on)
+      return 0
+      ;;
+    false|0|no|n|off)
+      return 1
+      ;;
+    *)
+      echo "[ERROR] LOADTEST_MONITORING_ENABLED must be true or false: ${1}" >&2
+      exit 1
+      ;;
+  esac
 }
 
 resolve_monitoring_source_dir() {
@@ -85,21 +101,26 @@ while IFS= read -r -d '' dashboard_file; do
 done < <(find "${MONITORING_SOURCE_DIR}/grafana/dashboards" -maxdepth 1 -type f -name '*.json' -print0)
 
 if command -v docker >/dev/null 2>&1; then
-  if (( monitoring_changed == 1 )) \
-    || ! container_running "ssd-loadtest-prometheus" \
-    || ! container_running "ssd-loadtest-grafana" \
-    || ! container_running "ssd-loadtest-node-exporter" \
-    || ! container_running "ssd-loadtest-cadvisor"; then
-    docker compose -f "${MONITORING_COMPOSE_FILE}" up -d
+  if is_enabled "${LOADTEST_MONITORING_ENABLED}"; then
+    if (( monitoring_changed == 1 )) \
+      || ! container_running "ssd-loadtest-prometheus" \
+      || ! container_running "ssd-loadtest-grafana" \
+      || ! container_running "ssd-loadtest-node-exporter" \
+      || ! container_running "ssd-loadtest-cadvisor"; then
+      docker compose -f "${MONITORING_COMPOSE_FILE}" up -d
+    else
+      echo "[INFO] Loadtest monitoring unchanged, skip compose up"
+    fi
   else
-    echo "[INFO] Monitoring unchanged, skip compose up"
+    echo "[INFO] Loadtest monitoring disabled, stop containers if they exist"
+    docker compose -f "${MONITORING_COMPOSE_FILE}" down --remove-orphans >/dev/null 2>&1 || true
   fi
 else
   echo "[ERROR] docker is not installed" >&2
   exit 1
 fi
 
-if command -v ufw >/dev/null 2>&1; then
+if is_enabled "${LOADTEST_MONITORING_ENABLED}" && command -v ufw >/dev/null 2>&1; then
   if ufw status | grep -q "Status: active"; then
     ufw allow "${GRAFANA_PORT}/tcp" >/dev/null 2>&1 || true
     ufw allow "${PROMETHEUS_PORT}/tcp" >/dev/null 2>&1 || true
@@ -107,7 +128,12 @@ if command -v ufw >/dev/null 2>&1; then
   fi
 fi
 
-echo "[INFO] Monitoring install complete"
-echo "[INFO] Grafana:    http://<server>:${GRAFANA_PORT}"
-echo "[INFO] Prometheus: http://<server>:${PROMETHEUS_PORT}"
-echo "[INFO] k6 Web UI:  http://<server>:${K6_DASHBOARD_PORT}"
+if is_enabled "${LOADTEST_MONITORING_ENABLED}"; then
+  echo "[INFO] Loadtest monitoring install complete"
+  echo "[INFO] Grafana:    http://<server>:${GRAFANA_PORT}"
+  echo "[INFO] Prometheus: http://<server>:${PROMETHEUS_PORT}"
+  echo "[INFO] k6 Web UI:  http://<server>:${K6_DASHBOARD_PORT}"
+else
+  echo "[INFO] Loadtest monitoring is disabled"
+  echo "[INFO] Set LOADTEST_MONITORING_ENABLED=true to start it"
+fi

--- a/k6/README.md
+++ b/k6/README.md
@@ -39,6 +39,19 @@
   - 실제 주소는 저장소에 기록하지 않고 내부 운영 문서 또는 시크릿 변수로 관리합니다.
   - 이 포트는 k6를 `K6_WEB_DASHBOARD=true`로 실행할 때만 열립니다.
 
+## 부하테스트 모니터링 기동
+부하테스트용 Prometheus/Grafana는 dev 서버 RAM 절약을 위해 평시에는 중지합니다.
+
+```bash
+sudo LOADTEST_MONITORING_ENABLED=true /home/ubuntu/ssd-deploy/deploy/ec2/install_monitoring.sh
+```
+
+부하테스트가 끝난 뒤에는 다시 중지합니다.
+
+```bash
+sudo LOADTEST_MONITORING_ENABLED=false /home/ubuntu/ssd-deploy/deploy/ec2/install_monitoring.sh
+```
+
 ## JVM 메트릭
 - SSD 앱은 `/actuator/prometheus`를 공개합니다.
 - Grafana `SSD Load Test JVM Overview`에서 아래 항목을 확인할 수 있습니다.


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #177 


<br>

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

- 부하테스트 모니터링이 컨테이너 삭제
- GC 설정 튜닝


<br>

## 🙏 Details

### 부하테스트 모니터링 컨테이너 중지

- 부하테스트 모니터링이 이전 CD 스크립트로 인해서 아직까지 실행중인 문제가 있었습니다.
- 이로 인해서 RAM에 여유가 사라지고 , 이를 해결하기 위해 swap을 사용함에 따라 STW가 길어지는 문제가 발생하였습니다.
- 이를 해결하기 위해 부하테스트 모니터링 컨테이너를 제거 -> 추후 부하테스트를 진행하는 인스턴스에만 띄울 수 있도록 스크립트와 문서를 수정하였습니다.

### Heap 크기 고정

- 이전에는 따로 설정을 넣지 않아서 JVM이 Heap의 크기를 동적으로 조절하였습니다.
- 이로 인해서 정확한 GC 디버깅이 힘들어지는 문제를 해결하기 위해서, GC의 초기 크기와 최대 크기를 고정하였습니다. 
```yml
export APP_LOG_DIR="/opt/ssd/logs"
            export APP_JAVA_TOOL_OPTIONS="-Xms256m -Xmx256m -Xlog:gc*,safepoint:file=/logs/gc.log:time,uptime,level,tags:filecount=5,filesize=10M"
```
- 이를 통해 추후 Heap이 부족해질때, 정량적인 근거를 통해 Heap 크기를 수정 할 수 있도록 변경하였습니다.
- Disk는 EBS를 20GB로 넉넉히 관리중이기에, GC 관련 로그도 저장하여 추후 문제 발생ㅅ ㅣ 참고하도록 하였습니다.
- 이제 슬슬 로그 수집 파이프라인에 대한 필요성이 생기네요.

<!-- 이번 PR에서 구현한 내용 중 포인트가 되는 부분을 자세하게 적어주세요 -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 애플리케이션 로그 관리 및 JVM 가비지 컬렉션 로깅 설정이 배포 구성에 추가되었습니다.
  * 운영 모니터링과 부하테스트 모니터링이 분리되어 각각 독립적으로 관리됩니다.
  * 부하테스트 모니터링은 기본적으로 비활성화되어 있으며, 필요시에만 활성화할 수 있습니다.
  * 모니터링 구성 및 활성화 방법에 대한 문서가 명확히 정리되었습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capstone-ssd/ssd-server/pull/183)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->