### PR TITLE
[FEATURE] 문서 검색 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ description = 'ssd'
 ext {
     set('springCloudVersion', "2025.1.0")
     set('springAiVersion', "2.0.0-M1")
+    set('testcontainersVersion', "1.21.3")
 }
 
 def stripBlockComments = { String content ->
@@ -168,7 +169,23 @@ subprojects {
         testClassesDirs = sourceSets.integrationTest.output.classesDirs
         classpath = sourceSets.integrationTest.runtimeClasspath
         shouldRunAfter tasks.named('test')
-        useJUnitPlatform()
+        useJUnitPlatform {
+            excludeTags 'performance'
+        }
+    }
+
+    tasks.register('performanceIntegrationTest', Test) {
+        description = 'Runs performance integration tests.'
+        group = 'verification'
+        testClassesDirs = sourceSets.integrationTest.output.classesDirs
+        classpath = sourceSets.integrationTest.runtimeClasspath
+        shouldRunAfter tasks.named('integrationTest')
+        systemProperty 'searchPerfDocs', System.getProperty('searchPerfDocs', '10000')
+        systemProperty 'searchPerfWarmups', System.getProperty('searchPerfWarmups', '10')
+        systemProperty 'searchPerfIterations', System.getProperty('searchPerfIterations', '50')
+        useJUnitPlatform {
+            includeTags 'performance'
+        }
     }
 
     tasks.register('verifyTestConventions') {

--- a/ssd-api/build.gradle
+++ b/ssd-api/build.gradle
@@ -27,6 +27,8 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'com.tngtech.archunit:archunit-junit5:1.3.0'
+    testImplementation "org.testcontainers:junit-jupiter:${testcontainersVersion}"
+    testImplementation "org.testcontainers:postgresql:${testcontainersVersion}"
     testRuntimeOnly 'com.h2database:h2'
 }
 

--- a/ssd-api/src/integrationTest/java/or/hyu/ssd/api/document/DocumentSearchPerformanceIntegrationTest.java
+++ b/ssd-api/src/integrationTest/java/or/hyu/ssd/api/document/DocumentSearchPerformanceIntegrationTest.java
@@ -30,7 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @Tag("performance")
 @Testcontainers
-@ActiveProfiles("local")
+@ActiveProfiles("integration-test")
 @SpringBootTest(classes = SsdApplication.class)
 class DocumentSearchPerformanceIntegrationTest {
 
@@ -57,8 +57,13 @@ class DocumentSearchPerformanceIntegrationTest {
         registry.add("spring.jpa.properties.hibernate.format_sql", () -> "false");
         registry.add("spring.data.redis.host", () -> "localhost");
         registry.add("spring.data.redis.port", () -> "6379");
+        registry.add("spring.jwt.secret", () -> "test-jwt-secret-test-jwt-secret-test-jwt-secret");
         registry.add("spring.security.oauth2.client.registration.kakao.client-id", () -> "test-client-id");
+        registry.add("spring.security.oauth2.client.registration.kakao.scope", () -> "profile_nickname,profile_image,account_email");
         registry.add("app.external-ai.base-url", () -> "http://localhost:9999");
+        registry.add("app.cookie.domain", () -> "");
+        registry.add("app.cookie.same-site", () -> "Lax");
+        registry.add("app.cookie.secure", () -> "false");
         registry.add("app.storage.s3.bucket", () -> "test-bucket");
         registry.add("app.storage.s3.region", () -> "ap-northeast-2");
         registry.add("app.storage.s3.access-key", () -> "test-access-key");

--- a/ssd-api/src/integrationTest/java/or/hyu/ssd/api/document/DocumentSearchPerformanceIntegrationTest.java
+++ b/ssd-api/src/integrationTest/java/or/hyu/ssd/api/document/DocumentSearchPerformanceIntegrationTest.java
@@ -1,0 +1,243 @@
+package or.hyu.ssd.api.document;
+
+import or.hyu.ssd.api.bootstrap.SsdApplication;
+import or.hyu.ssd.application.document.DocumentQueryFacade;
+import or.hyu.ssd.document.application.result.DocumentListItemResult;
+import or.hyu.ssd.document.application.support.DocumentSort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Tag("performance")
+@Testcontainers
+@ActiveProfiles("local")
+@SpringBootTest(classes = SsdApplication.class)
+class DocumentSearchPerformanceIntegrationTest {
+
+    private static final int DEFAULT_DOCUMENT_COUNT = 10_000;
+    private static final int DEFAULT_WARMUPS = 10;
+    private static final int DEFAULT_ITERATIONS = 50;
+    private static final int BATCH_SIZE = 1_000;
+    private static final String KEYWORD = "사업계획서";
+
+    @Container
+    static final PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+
+    @DynamicPropertySource
+    static void properties(DynamicPropertyRegistry registry) {
+        // given
+
+        // when
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+        registry.add("spring.datasource.driver-class-name", postgres::getDriverClassName);
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
+        registry.add("spring.jpa.properties.hibernate.show_sql", () -> "false");
+        registry.add("spring.jpa.properties.hibernate.format_sql", () -> "false");
+        registry.add("spring.data.redis.host", () -> "localhost");
+        registry.add("spring.data.redis.port", () -> "6379");
+        registry.add("spring.security.oauth2.client.registration.kakao.client-id", () -> "test-client-id");
+        registry.add("app.external-ai.base-url", () -> "http://localhost:9999");
+        registry.add("app.storage.s3.bucket", () -> "test-bucket");
+        registry.add("app.storage.s3.region", () -> "ap-northeast-2");
+        registry.add("app.storage.s3.access-key", () -> "test-access-key");
+        registry.add("app.storage.s3.secret-key", () -> "test-secret-key");
+        registry.add("sentry.dsn", () -> "");
+
+        // then
+    }
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private DocumentQueryFacade documentQueryFacade;
+
+    @Test
+    @DisplayName("searchDocuments()는 대량 문서에서 제목 검색 성능 기준값을 출력한다")
+    void searchDocuments_printsPerformanceBaseline() {
+        // given
+        int documentCount = Integer.getInteger("searchPerfDocs", DEFAULT_DOCUMENT_COUNT);
+        int warmups = Integer.getInteger("searchPerfWarmups", DEFAULT_WARMUPS);
+        int iterations = Integer.getInteger("searchPerfIterations", DEFAULT_ITERATIONS);
+        Long ownerId = prepareDataset(documentCount);
+
+        // when
+        SearchPerformanceResult result = measure(
+                () -> documentQueryFacade.searchDocuments(ownerId, KEYWORD, DocumentSort.MODIFIED),
+                warmups,
+                iterations
+        );
+        List<DocumentListItemResult> searchResults = documentQueryFacade.searchDocuments(ownerId, KEYWORD, DocumentSort.MODIFIED);
+
+        // then
+        assertThat(searchResults).isNotEmpty();
+        assertThat(searchResults).allMatch(document -> document.title().contains(KEYWORD));
+        assertThat(searchResults).allMatch(document -> document.id() <= documentCount);
+        System.out.printf(
+                "[DocumentSearchPerformance] docs=%d, warmups=%d, iterations=%d, keyword=%s, resultCount=%d, avg=%dms, p95=%dms, p99=%dms%n",
+                documentCount,
+                warmups,
+                iterations,
+                KEYWORD,
+                searchResults.size(),
+                result.avgMillis(),
+                result.p95Millis(),
+                result.p99Millis()
+        );
+    }
+
+    private Long prepareDataset(int documentCount) {
+        jdbcTemplate.execute("TRUNCATE TABLE documents, members RESTART IDENTITY CASCADE");
+        Long ownerId = insertMember("owner@example.com");
+        Long otherMemberId = insertMember("other@example.com");
+        insertDocuments(ownerId, documentCount);
+        insertOtherMemberDocument(otherMemberId);
+        return ownerId;
+    }
+
+    private Long insertMember(String email) {
+        return jdbcTemplate.queryForObject(
+                """
+                INSERT INTO members (name, email, profile_image_url, role, created_at, updated_at)
+                VALUES (?, ?, ?, ?, now(), now())
+                RETURNING id
+                """,
+                Long.class,
+                "테스터",
+                email,
+                "",
+                "ROLE_AUTHOR"
+        );
+    }
+
+    private void insertDocuments(Long memberId, int documentCount) {
+        for (int start = 1; start <= documentCount; start += BATCH_SIZE) {
+            int from = start;
+            int size = Math.min(BATCH_SIZE, documentCount - start + 1);
+            jdbcTemplate.batchUpdate(documentInsertSql(), new BatchPreparedStatementSetter() {
+                @Override
+                public void setValues(PreparedStatement ps, int index) throws SQLException {
+                    int sequence = from + index;
+                    boolean matched = sequence % 100 == 0;
+                    LocalDateTime timestamp = LocalDateTime.now().minusSeconds(documentCount - sequence);
+                    ps.setString(1, matched ? "AI 사업계획서 " + sequence : "일반 문서 " + sequence);
+                    ps.setString(2, "성능 테스트 본문 " + sequence);
+                    ps.setBoolean(3, false);
+                    ps.setString(4, "EVALUATION");
+                    ps.setLong(5, memberId);
+                    ps.setObject(6, timestamp);
+                    ps.setObject(7, timestamp);
+                    ps.setBoolean(8, false);
+                    ps.setLong(9, 0L);
+                }
+
+                @Override
+                public int getBatchSize() {
+                    return size;
+                }
+            });
+        }
+    }
+
+    private void insertOtherMemberDocument(Long memberId) {
+        jdbcTemplate.update(
+                documentInsertSql(),
+                "AI 사업계획서 노출되면 안 되는 문서",
+                "다른 회원 문서",
+                false,
+                "EVALUATION",
+                memberId,
+                LocalDateTime.now(),
+                LocalDateTime.now(),
+                false,
+                0L
+        );
+    }
+
+    private String documentInsertSql() {
+        return """
+                INSERT INTO documents (
+                    title, content, bookmark, purpose, member_id, created_at, updated_at,
+                    external_ai_processed, version,
+                    checklist_differentiation_is_clear,
+                    checklist_differentiation_is_realistic,
+                    checklist_target_specific_advantage,
+                    checklist_entry_barrier_exists,
+                    checklist_problem_is_clear,
+                    checklist_problem_is_real,
+                    checklist_target_and_context_are_specific,
+                    checklist_existing_solution_has_limits,
+                    checklist_market_definition_is_correct,
+                    checklist_market_size_is_realistic,
+                    checklist_willingness_to_pay_is_clear,
+                    checklist_revenue_model_is_clear,
+                    checklist_problem_founder_fit,
+                    checklist_experience_alignment,
+                    checklist_team_structure_is_clear,
+                    checklist_capability_gap_plan_exists
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false)
+                """;
+    }
+
+    private SearchPerformanceResult measure(Runnable task, int warmups, int iterations) {
+        for (int i = 0; i < warmups; i++) {
+            task.run();
+        }
+
+        List<Long> elapsedNanos = new ArrayList<>();
+        for (int i = 0; i < iterations; i++) {
+            long start = System.nanoTime();
+            task.run();
+            elapsedNanos.add(System.nanoTime() - start);
+        }
+        Collections.sort(elapsedNanos);
+        return new SearchPerformanceResult(
+                averageMillis(elapsedNanos),
+                percentileMillis(elapsedNanos, 95),
+                percentileMillis(elapsedNanos, 99)
+        );
+    }
+
+    private long averageMillis(List<Long> elapsedNanos) {
+        return Math.round(elapsedNanos.stream()
+                .mapToLong(Long::longValue)
+                .average()
+                .orElse(0.0) / TimeUnit.MILLISECONDS.toNanos(1));
+    }
+
+    private long percentileMillis(List<Long> elapsedNanos, int percentile) {
+        int index = (int) Math.ceil(elapsedNanos.size() * (percentile / 100.0)) - 1;
+        int safeIndex = Math.max(0, Math.min(index, elapsedNanos.size() - 1));
+        return TimeUnit.NANOSECONDS.toMillis(elapsedNanos.get(safeIndex));
+    }
+
+    private record SearchPerformanceResult(
+            long avgMillis,
+            long p95Millis,
+            long p99Millis
+    ) {
+    }
+}

--- a/ssd-api/src/integrationTest/java/or/hyu/ssd/api/document/DocumentSearchPerformanceIntegrationTest.java
+++ b/ssd-api/src/integrationTest/java/or/hyu/ssd/api/document/DocumentSearchPerformanceIntegrationTest.java
@@ -52,7 +52,7 @@ class DocumentSearchPerformanceIntegrationTest {
         registry.add("spring.datasource.username", postgres::getUsername);
         registry.add("spring.datasource.password", postgres::getPassword);
         registry.add("spring.datasource.driver-class-name", postgres::getDriverClassName);
-        registry.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "create");
         registry.add("spring.jpa.properties.hibernate.show_sql", () -> "false");
         registry.add("spring.jpa.properties.hibernate.format_sql", () -> "false");
         registry.add("spring.data.redis.host", () -> "localhost");
@@ -75,8 +75,8 @@ class DocumentSearchPerformanceIntegrationTest {
     private DocumentQueryFacade documentQueryFacade;
 
     @Test
-    @DisplayName("searchDocuments()는 대량 문서에서 제목 검색 성능 기준값을 출력한다")
-    void searchDocuments_printsPerformanceBaseline() {
+    @DisplayName("searchDocuments()는 대량 문서에서 포함 검색과 Prefix 검색 성능을 비교한다")
+    void searchDocuments_comparesContainsAndPrefixPerformance() {
         // given
         int documentCount = Integer.getInteger("searchPerfDocs", DEFAULT_DOCUMENT_COUNT);
         int warmups = Integer.getInteger("searchPerfWarmups", DEFAULT_WARMUPS);
@@ -84,27 +84,53 @@ class DocumentSearchPerformanceIntegrationTest {
         Long ownerId = prepareDataset(documentCount);
 
         // when
-        SearchPerformanceResult result = measure(
+        SearchPerformanceResult containsResult = measure(
                 () -> documentQueryFacade.searchDocuments(ownerId, KEYWORD, DocumentSort.MODIFIED),
                 warmups,
                 iterations
         );
-        List<DocumentListItemResult> searchResults = documentQueryFacade.searchDocuments(ownerId, KEYWORD, DocumentSort.MODIFIED);
+        SearchPerformanceResult prefixResult = measure(
+                () -> documentQueryFacade.searchDocumentsByTitlePrefix(ownerId, KEYWORD, DocumentSort.MODIFIED),
+                warmups,
+                iterations
+        );
+        List<DocumentListItemResult> containsSearchResults = documentQueryFacade.searchDocuments(ownerId, KEYWORD, DocumentSort.MODIFIED);
+        List<DocumentListItemResult> prefixSearchResults = documentQueryFacade.searchDocumentsByTitlePrefix(ownerId, KEYWORD, DocumentSort.MODIFIED);
 
         // then
-        assertThat(searchResults).isNotEmpty();
-        assertThat(searchResults).allMatch(document -> document.title().contains(KEYWORD));
-        assertThat(searchResults).allMatch(document -> document.id() <= documentCount);
+        assertThat(containsSearchResults).isNotEmpty();
+        assertThat(prefixSearchResults).hasSameSizeAs(containsSearchResults);
+        assertThat(containsSearchResults).allMatch(document -> document.title().contains(KEYWORD));
+        assertThat(prefixSearchResults).allMatch(document -> document.title().startsWith(KEYWORD));
+        assertThat(containsSearchResults).allMatch(document -> document.id() <= documentCount);
+        assertThat(prefixSearchResults).allMatch(document -> document.id() <= documentCount);
         System.out.printf(
-                "[DocumentSearchPerformance] docs=%d, warmups=%d, iterations=%d, keyword=%s, resultCount=%d, avg=%dms, p95=%dms, p99=%dms%n",
+                "[DocumentSearchPerformance] mode=CONTAINS, docs=%d, warmups=%d, iterations=%d, keyword=%s, resultCount=%d, avg=%dms, p95=%dms, p99=%dms%n",
                 documentCount,
                 warmups,
                 iterations,
                 KEYWORD,
-                searchResults.size(),
-                result.avgMillis(),
-                result.p95Millis(),
-                result.p99Millis()
+                containsSearchResults.size(),
+                containsResult.avgMillis(),
+                containsResult.p95Millis(),
+                containsResult.p99Millis()
+        );
+        System.out.printf(
+                "[DocumentSearchPerformance] mode=PREFIX, docs=%d, warmups=%d, iterations=%d, keyword=%s, resultCount=%d, avg=%dms, p95=%dms, p99=%dms%n",
+                documentCount,
+                warmups,
+                iterations,
+                KEYWORD,
+                prefixSearchResults.size(),
+                prefixResult.avgMillis(),
+                prefixResult.p95Millis(),
+                prefixResult.p99Millis()
+        );
+        System.out.printf(
+                "[DocumentSearchPerformance] prefixImprovement=avg %.2f%%, p95 %.2f%%, p99 %.2f%%%n",
+                improvementRate(containsResult.avgMillis(), prefixResult.avgMillis()),
+                improvementRate(containsResult.p95Millis(), prefixResult.p95Millis()),
+                improvementRate(containsResult.p99Millis(), prefixResult.p99Millis())
         );
     }
 
@@ -142,7 +168,7 @@ class DocumentSearchPerformanceIntegrationTest {
                     int sequence = from + index;
                     boolean matched = sequence % 100 == 0;
                     LocalDateTime timestamp = LocalDateTime.now().minusSeconds(documentCount - sequence);
-                    ps.setString(1, matched ? "AI 사업계획서 " + sequence : "일반 문서 " + sequence);
+                    ps.setString(1, matched ? KEYWORD + " AI " + sequence : "일반 문서 " + sequence);
                     ps.setString(2, "성능 테스트 본문 " + sequence);
                     ps.setBoolean(3, false);
                     ps.setString(4, "EVALUATION");
@@ -164,7 +190,7 @@ class DocumentSearchPerformanceIntegrationTest {
     private void insertOtherMemberDocument(Long memberId) {
         jdbcTemplate.update(
                 documentInsertSql(),
-                "AI 사업계획서 노출되면 안 되는 문서",
+                KEYWORD + " 노출되면 안 되는 문서",
                 "다른 회원 문서",
                 false,
                 "EVALUATION",
@@ -232,6 +258,13 @@ class DocumentSearchPerformanceIntegrationTest {
         int index = (int) Math.ceil(elapsedNanos.size() * (percentile / 100.0)) - 1;
         int safeIndex = Math.max(0, Math.min(index, elapsedNanos.size() - 1));
         return TimeUnit.NANOSECONDS.toMillis(elapsedNanos.get(safeIndex));
+    }
+
+    private double improvementRate(long before, long after) {
+        if (before == 0) {
+            return 0.0;
+        }
+        return ((double) before - after) / before * 100.0;
     }
 
     private record SearchPerformanceResult(

--- a/ssd-api/src/main/java/or/hyu/ssd/api/document/controller/DocumentController.java
+++ b/ssd-api/src/main/java/or/hyu/ssd/api/document/controller/DocumentController.java
@@ -28,6 +28,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.PositiveOrZero;
 import org.springframework.web.multipart.MultipartFile;
@@ -300,6 +301,54 @@ public class DocumentController {
                 .map(DocumentListItemResponse::from)
                 .toList();
         return ResponseEntity.ok(ApiResponse.ok(list, "문서 목록이 조회되었습니다"));
+    }
+
+    @GetMapping("/v1/documents/search")
+    @Operation(
+            summary = "문서 제목 검색",
+            description = """
+                    ### 개요
+                    - 로그인한 회원의 문서 중 제목에 검색어가 포함된 문서를 조회합니다.
+                    - 검색은 제목 기준 LIKE 검색으로 수행합니다.
+
+                    ### 인증
+                    - Authorization: Bearer {accessToken}
+
+                    ### 요청
+                    - Query keyword (required): 검색어
+                    - Query sort (optional, default=LATEST)
+                      - LATEST: 생성일 최신순
+                      - OLDEST: 생성일 오래된순
+                      - NAME: 제목 오름차순
+                      - MODIFIED: 수정일 최신순
+
+                    ### 응답
+                    - 200 OK
+                    - data[]
+                      - id: 문서 ID
+                      - title: 제목
+                      - purpose: 문서 목적 (`WRITING`, `EVALUATION`)
+                      - folderId: 폴더 ID (없으면 루트)
+                      - updatedAt: 마지막 수정 시각
+                      - bookmark: 즐겨찾기 여부
+
+                    ### 오류
+                    - REQ40002: 검색어가 비어 있음
+                    - MEMBER_NOT_FOUND: 인증 정보 없음/회원 없음
+                    - TOKEN4030x: 토큰 누락/만료/위조
+                    """
+    )
+    public ResponseEntity<ApiResponse<List<DocumentListItemResponse>>> searchDocuments(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @Parameter(description = "검색어", example = "사업계획서")
+            @RequestParam(name = "keyword") @NotBlank(message = "검색어는 필수입니다") String keyword,
+            @Parameter(description = "정렬 옵션", schema = @Schema(allowableValues = {"LATEST","OLDEST","NAME","MODIFIED"}))
+            @RequestParam(name = "sort", defaultValue = "LATEST") DocumentSort sort
+    ) {
+        List<DocumentListItemResponse> list = documentQueryFacade.searchDocuments(user.getMember().getId(), keyword, sort).stream()
+                .map(DocumentListItemResponse::from)
+                .toList();
+        return ResponseEntity.ok(ApiResponse.ok(list, "문서 검색 결과가 조회되었습니다"));
     }
 
     @PatchMapping("/v1/documents/{id}/bookmark")

--- a/ssd-application/src/main/java/or/hyu/ssd/application/document/DocumentQueryFacade.java
+++ b/ssd-application/src/main/java/or/hyu/ssd/application/document/DocumentQueryFacade.java
@@ -28,4 +28,8 @@ public class DocumentQueryFacade {
     public List<DocumentListItemResult> searchDocuments(Long memberId, String keyword, DocumentSort sortOption) {
         return documentQueryService.searchDocuments(memberId, keyword, sortOption);
     }
+
+    public List<DocumentListItemResult> searchDocumentsByTitlePrefix(Long memberId, String keyword, DocumentSort sortOption) {
+        return documentQueryService.searchDocumentsByTitlePrefix(memberId, keyword, sortOption);
+    }
 }

--- a/ssd-application/src/main/java/or/hyu/ssd/application/document/DocumentQueryFacade.java
+++ b/ssd-application/src/main/java/or/hyu/ssd/application/document/DocumentQueryFacade.java
@@ -24,4 +24,8 @@ public class DocumentQueryFacade {
     public List<DocumentListItemResult> listDocuments(Long memberId, DocumentSort sortOption, Long folderId) {
         return documentQueryService.listDocuments(memberId, sortOption, folderId);
     }
+
+    public List<DocumentListItemResult> searchDocuments(Long memberId, String keyword, DocumentSort sortOption) {
+        return documentQueryService.searchDocuments(memberId, keyword, sortOption);
+    }
 }

--- a/ssd-domain/src/main/java/or/hyu/ssd/document/application/service/DocumentQueryService.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/document/application/service/DocumentQueryService.java
@@ -62,6 +62,15 @@ public class DocumentQueryService {
                 .collect(Collectors.toList());
     }
 
+    public List<DocumentListItemResult> searchDocumentsByTitlePrefix(Long memberId, String keyword, DocumentSort sortOption) {
+        assertAuthenticatedMember(memberId);
+        String normalizedKeyword = normalizeKeyword(keyword);
+
+        return documentRepository.findAllByMember_IdAndTitleStartingWith(memberId, normalizedKeyword, toSort(sortOption)).stream()
+                .map(DocumentListItemResult::of)
+                .collect(Collectors.toList());
+    }
+
     private Sort toSort(DocumentSort sortOption) {
         return switch (sortOption) {
             case LATEST -> Sort.by(Sort.Order.desc("createdAt"));

--- a/ssd-domain/src/main/java/or/hyu/ssd/document/application/service/DocumentQueryService.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/document/application/service/DocumentQueryService.java
@@ -36,12 +36,7 @@ public class DocumentQueryService {
     public List<DocumentListItemResult> listDocuments(Long memberId, DocumentSort sortOption, Long folderId) {
         assertAuthenticatedMember(memberId);
 
-        Sort sort = switch (sortOption) {
-            case LATEST -> Sort.by(Sort.Order.desc("createdAt"));
-            case OLDEST -> Sort.by(Sort.Order.asc("createdAt"));
-            case NAME -> Sort.by(Sort.Order.asc("title"));
-            case MODIFIED -> Sort.by(Sort.Order.desc("updatedAt"));
-        };
+        Sort sort = toSort(sortOption);
 
         List<Document> documents;
         if (folderId == null) {
@@ -56,6 +51,31 @@ public class DocumentQueryService {
         return documents.stream()
                 .map(DocumentListItemResult::of)
                 .collect(Collectors.toList());
+    }
+
+    public List<DocumentListItemResult> searchDocuments(Long memberId, String keyword, DocumentSort sortOption) {
+        assertAuthenticatedMember(memberId);
+        String normalizedKeyword = normalizeKeyword(keyword);
+
+        return documentRepository.findAllByMember_IdAndTitleContaining(memberId, normalizedKeyword, toSort(sortOption)).stream()
+                .map(DocumentListItemResult::of)
+                .collect(Collectors.toList());
+    }
+
+    private Sort toSort(DocumentSort sortOption) {
+        return switch (sortOption) {
+            case LATEST -> Sort.by(Sort.Order.desc("createdAt"));
+            case OLDEST -> Sort.by(Sort.Order.asc("createdAt"));
+            case NAME -> Sort.by(Sort.Order.asc("title"));
+            case MODIFIED -> Sort.by(Sort.Order.desc("updatedAt"));
+        };
+    }
+
+    private String normalizeKeyword(String keyword) {
+        if (keyword == null || keyword.isBlank()) {
+            throw new DocumentException(ErrorCode.REQUEST_BODY_INVALID_VALUE, "검색어는 공백일 수 없습니다");
+        }
+        return keyword.trim();
     }
 
     private Document loadDocument(Long documentId) {

--- a/ssd-domain/src/main/java/or/hyu/ssd/document/repository/DocumentRepository.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/document/repository/DocumentRepository.java
@@ -15,6 +15,8 @@ public interface DocumentRepository {
 
     List<Document> findAllByMember_IdAndTitleContaining(Long memberId, String keyword, Sort sort);
 
+    List<Document> findAllByMember_IdAndTitleStartingWith(Long memberId, String keyword, Sort sort);
+
     List<Document> findAllByMember_IdAndFolder_Id(Long memberId, Long folderId, Sort sort);
 
     List<Document> findAllByMember_IdAndFolderIsNull(Long memberId, Sort sort);

--- a/ssd-domain/src/main/java/or/hyu/ssd/document/repository/DocumentRepository.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/document/repository/DocumentRepository.java
@@ -13,6 +13,8 @@ public interface DocumentRepository {
 
     List<Document> findAllByMember_Id(Long memberId, Sort sort);
 
+    List<Document> findAllByMember_IdAndTitleContaining(Long memberId, String keyword, Sort sort);
+
     List<Document> findAllByMember_IdAndFolder_Id(Long memberId, Long folderId, Sort sort);
 
     List<Document> findAllByMember_IdAndFolderIsNull(Long memberId, Sort sort);

--- a/ssd-domain/src/test/java/or/hyu/ssd/document/application/service/DocumentQueryServiceTest.java
+++ b/ssd-domain/src/test/java/or/hyu/ssd/document/application/service/DocumentQueryServiceTest.java
@@ -117,6 +117,28 @@ class DocumentQueryServiceTest {
     }
 
     @Test
+    @DisplayName("searchDocumentsByTitlePrefix()는 회원의 문서 중 제목이 검색어로 시작하는 문서를 조회한다")
+    void searchDocumentsByTitlePrefix_returnsMatchedDocumentsByTitlePrefix() {
+        // given
+        Member member = member(1L);
+        Long user = member.getId();
+        Document document = document(201L, "사업계획서 AI", null, member, true);
+        Sort sort = Sort.by(Sort.Order.desc("updatedAt"));
+        when(documentRepository.findAllByMember_IdAndTitleStartingWith(1L, "사업", sort))
+                .thenReturn(List.of(document));
+
+        // when
+        List<DocumentListItemResult> results = documentQueryService.searchDocumentsByTitlePrefix(user, " 사업 ", DocumentSort.MODIFIED);
+
+        // then
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).id()).isEqualTo(201L);
+        assertThat(results.get(0).title()).isEqualTo("사업계획서 AI");
+        assertThat(results.get(0).bookmark()).isTrue();
+        verify(documentRepository).findAllByMember_IdAndTitleStartingWith(1L, "사업", sort);
+    }
+
+    @Test
     @DisplayName("searchDocuments()는 검색어가 공백이면 예외를 던진다")
     void searchDocuments_rejectsBlankKeyword() {
         // given

--- a/ssd-domain/src/test/java/or/hyu/ssd/document/application/service/DocumentQueryServiceTest.java
+++ b/ssd-domain/src/test/java/or/hyu/ssd/document/application/service/DocumentQueryServiceTest.java
@@ -11,6 +11,7 @@ import or.hyu.ssd.document.repository.FolderRepository;
 import or.hyu.ssd.document.application.support.DocumentSort;
 import or.hyu.ssd.document.application.result.DocumentDetailResult;
 import or.hyu.ssd.document.application.result.DocumentListItemResult;
+import or.hyu.ssd.common.exception.DocumentException;
 import or.hyu.ssd.member.domain.model.Member;
 import or.hyu.ssd.member.domain.model.Role;
 import org.junit.jupiter.api.DisplayName;
@@ -25,6 +26,9 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -88,6 +92,42 @@ class DocumentQueryServiceTest {
         assertThat(results.get(0).purpose()).isEqualTo(DocumentPurpose.EVALUATION);
         assertThat(results.get(0).folderId()).isNull();
         assertThat(results.get(0).bookmark()).isTrue();
+    }
+
+    @Test
+    @DisplayName("searchDocuments()는 회원의 문서 중 제목에 검색어가 포함된 문서를 조회한다")
+    void searchDocuments_returnsMatchedDocumentsByTitle() {
+        // given
+        Member member = member(1L);
+        Long user = member.getId();
+        Document document = document(200L, "AI 사업계획서", null, member, true);
+        Sort sort = Sort.by(Sort.Order.desc("updatedAt"));
+        when(documentRepository.findAllByMember_IdAndTitleContaining(1L, "사업", sort))
+                .thenReturn(List.of(document));
+
+        // when
+        List<DocumentListItemResult> results = documentQueryService.searchDocuments(user, " 사업 ", DocumentSort.MODIFIED);
+
+        // then
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).id()).isEqualTo(200L);
+        assertThat(results.get(0).title()).isEqualTo("AI 사업계획서");
+        assertThat(results.get(0).bookmark()).isTrue();
+        verify(documentRepository).findAllByMember_IdAndTitleContaining(1L, "사업", sort);
+    }
+
+    @Test
+    @DisplayName("searchDocuments()는 검색어가 공백이면 예외를 던진다")
+    void searchDocuments_rejectsBlankKeyword() {
+        // given
+        Member member = member(1L);
+
+        // when
+        assertThatThrownBy(() -> documentQueryService.searchDocuments(member.getId(), "   ", DocumentSort.LATEST))
+                .isInstanceOf(DocumentException.class);
+
+        // then
+        verifyNoInteractions(documentRepository);
     }
 
     private Document document(Long id, String title, Folder folder, Member member) {

--- a/ssd-infra/src/main/java/or/hyu/ssd/infra/persistence/document/repository/DocumentRepositoryImpl.java
+++ b/ssd-infra/src/main/java/or/hyu/ssd/infra/persistence/document/repository/DocumentRepositoryImpl.java
@@ -41,6 +41,13 @@ public class DocumentRepositoryImpl implements DocumentRepository {
     }
 
     @Override
+    public List<Document> findAllByMember_IdAndTitleStartingWith(Long memberId, String keyword, Sort sort) {
+        return documentJpaRepository.findAllByMember_IdAndTitleStartingWith(memberId, keyword, sort).stream()
+                .map(DocumentPersistenceMapper::toDomain)
+                .toList();
+    }
+
+    @Override
     public List<Document> findAllByMember_IdAndFolder_Id(Long memberId, Long folderId, Sort sort) {
         return documentJpaRepository.findAllByMember_IdAndFolder_Id(memberId, folderId, sort).stream()
                 .map(DocumentPersistenceMapper::toDomain)

--- a/ssd-infra/src/main/java/or/hyu/ssd/infra/persistence/document/repository/DocumentRepositoryImpl.java
+++ b/ssd-infra/src/main/java/or/hyu/ssd/infra/persistence/document/repository/DocumentRepositoryImpl.java
@@ -34,6 +34,13 @@ public class DocumentRepositoryImpl implements DocumentRepository {
     }
 
     @Override
+    public List<Document> findAllByMember_IdAndTitleContaining(Long memberId, String keyword, Sort sort) {
+        return documentJpaRepository.findAllByMember_IdAndTitleContaining(memberId, keyword, sort).stream()
+                .map(DocumentPersistenceMapper::toDomain)
+                .toList();
+    }
+
+    @Override
     public List<Document> findAllByMember_IdAndFolder_Id(Long memberId, Long folderId, Sort sort) {
         return documentJpaRepository.findAllByMember_IdAndFolder_Id(memberId, folderId, sort).stream()
                 .map(DocumentPersistenceMapper::toDomain)

--- a/ssd-infra/src/main/java/or/hyu/ssd/infra/persistence/document/repository/jpa/DocumentJpaRepository.java
+++ b/ssd-infra/src/main/java/or/hyu/ssd/infra/persistence/document/repository/jpa/DocumentJpaRepository.java
@@ -9,6 +9,8 @@ import java.util.List;
 public interface DocumentJpaRepository extends JpaRepository<DocumentJpaEntity, Long> {
     List<DocumentJpaEntity> findAllByMember_Id(Long memberId, Sort sort);
 
+    List<DocumentJpaEntity> findAllByMember_IdAndTitleContaining(Long memberId, String keyword, Sort sort);
+
     List<DocumentJpaEntity> findAllByMember_IdAndFolder_Id(Long memberId, Long folderId, Sort sort);
 
     List<DocumentJpaEntity> findAllByMember_IdAndFolderIsNull(Long memberId, Sort sort);

--- a/ssd-infra/src/main/java/or/hyu/ssd/infra/persistence/document/repository/jpa/DocumentJpaRepository.java
+++ b/ssd-infra/src/main/java/or/hyu/ssd/infra/persistence/document/repository/jpa/DocumentJpaRepository.java
@@ -2,6 +2,7 @@ package or.hyu.ssd.infra.persistence.document.repository.jpa;
 
 import or.hyu.ssd.infra.persistence.document.entity.DocumentJpaEntity;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -9,8 +10,10 @@ import java.util.List;
 public interface DocumentJpaRepository extends JpaRepository<DocumentJpaEntity, Long> {
     List<DocumentJpaEntity> findAllByMember_Id(Long memberId, Sort sort);
 
+    @EntityGraph(attributePaths = {"folder", "member"})
     List<DocumentJpaEntity> findAllByMember_IdAndTitleContaining(Long memberId, String keyword, Sort sort);
 
+    @EntityGraph(attributePaths = {"folder", "member"})
     List<DocumentJpaEntity> findAllByMember_IdAndTitleStartingWith(Long memberId, String keyword, Sort sort);
 
     List<DocumentJpaEntity> findAllByMember_IdAndFolder_Id(Long memberId, Long folderId, Sort sort);

--- a/ssd-infra/src/main/java/or/hyu/ssd/infra/persistence/document/repository/jpa/DocumentJpaRepository.java
+++ b/ssd-infra/src/main/java/or/hyu/ssd/infra/persistence/document/repository/jpa/DocumentJpaRepository.java
@@ -11,6 +11,8 @@ public interface DocumentJpaRepository extends JpaRepository<DocumentJpaEntity, 
 
     List<DocumentJpaEntity> findAllByMember_IdAndTitleContaining(Long memberId, String keyword, Sort sort);
 
+    List<DocumentJpaEntity> findAllByMember_IdAndTitleStartingWith(Long memberId, String keyword, Sort sort);
+
     List<DocumentJpaEntity> findAllByMember_IdAndFolder_Id(Long memberId, Long folderId, Sort sort);
 
     List<DocumentJpaEntity> findAllByMember_IdAndFolderIsNull(Long memberId, Sort sort);


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #185 


<br>

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- title기반 회원 문서 검색 API를 구현하였습니다.
- 문서 검색 테스트 파이프라인을 구축했습니다.


<br>

## 🙏 Details

### 1. 검색 API 구현 및 테스트 파이프라인을 통한 성능 검토

<!-- 이번 PR에서 구현한 내용 중 포인트가 되는 부분을 자세하게 적어주세요 -->

Like 쿼리에 기반한 문서 검색 API를 구현하고 성능을 테스트하였습니다.
간단한 테스트이기 때문에 K6에 기반한 부하테스트가 아닌, 테스트 컨테이너를 통해 정량적 지표를 수집해보았습니다.

파이프라인은 아래와 같습니다.
```mermaid
flowchart LR
    A["PostgreSQL Testcontainer 실행"] --> B["회원/문서 테스트 데이터 삽입"]
    B --> C["Warm-up 10회"]
    C --> D["검색 Facade 50회 반복 호출"]
    D --> E["각 요청 시간 기록"]
    E --> F["avg / p95 / p99 계산"]

```

결과는 아래와 같습니다.

지표 | 의미 | 해석
-- | -- | --
avg=6ms | 평균 검색 시간 | 현재 1만 건 기준으로는 충분히 빠름
p95=6ms | 95% 요청이 6ms 이하 | 응답 시간이 안정적임
p99=9ms | 가장 느린 1% 근처 요청 | tail latency도 크지 않음
resultCount=100 | 실제 검색 결과 수 | 검색어 포함 문서만 정상 반환
다른 회원 문서 제외 | 권한 필터 검증 | 본인 문서 조건이 유지됨
사실 꽤나 준수한 지표를 보였습니다. 그 이유는 아래와 같습니다.
- 구조화된 데이터 셋
- 적은 데이터 셋
- 정확한 검색 키워드 주입

사실 여기서 "사업게획서" 라는 오타만 내도 검색이 진행되지 않습니다. 관련도 또한 고려되지 않고 있죠.
사용자가 실제로 사용하기 위한 API로는 몇가지 문제점이 존재합니다.

<br>

### 2. Prefix 인덱스 도입을 통한 부분 최적화 도입

B-Tree의 범위탐색 장점을 극적으로 활용하기 위해 Prefix 검색으로 수정한 후, 결과입니다.

데이터 수 | 방식 | 결과 수 | avg | p95 | p99
-- | -- | -- | -- | -- | --
10,000 | CONTAINS | 100 | 6ms | 8ms | 14ms
10,000 | PREFIX | 100 | 4ms | 5ms | 6ms
100,000 | CONTAINS | 1,000 | 29ms | 35ms | 72ms
100,000 | PREFIX | 1,000 | 24ms | 27ms | 28ms

성능상 큰 개선이 있었지만, Prefix의 경우 `사업계획서%`와 같이 검색하기 때문에 `AI 사업계획서`와 같이 앞부분에 변동사항이 있으면 읽지 못합니다.
하지만 어차피 형태소 기반 풀텍스트 검색은 Like쿼리로 불가능하기 때문에 정확도의 이점을 챙기는 것보단 성능상 이점을 가져가는 것이 좋다고 판단했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 문서를 제목 키워드로 검색할 수 있는 새로운 검색 기능이 추가되었습니다.
  * 검색 결과에 정렬 옵션(최신순 등)을 적용할 수 있습니다.
  * 전체 제목 일치 및 제목 시작 문자 기준 검색이 지원됩니다.

* **테스트**
  * 문서 검색 성능 검증을 위한 통합 테스트가 추가되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capstone-ssd/ssd-server/pull/186)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->