### PR TITLE
[FEATURE] 문서 폴더 이동 API 구현

### DIFF
--- a/ssd-api/src/main/java/or/hyu/ssd/api/document/controller/DocumentController.java
+++ b/ssd-api/src/main/java/or/hyu/ssd/api/document/controller/DocumentController.java
@@ -11,6 +11,8 @@ import or.hyu.ssd.api.document.response.CreateDocumentResponse;
 import or.hyu.ssd.api.document.request.DocumentImageMetaRequest;
 import or.hyu.ssd.api.document.response.GetDocumentResponse;
 import or.hyu.ssd.api.document.response.DocumentListItemResponse;
+import or.hyu.ssd.api.document.request.MoveDocumentFolderRequest;
+import or.hyu.ssd.api.document.response.MoveDocumentFolderResponse;
 import or.hyu.ssd.api.document.request.UpdateDocumentRequest;
 import or.hyu.ssd.api.document.response.UpdateDocumentResponse;
 import or.hyu.ssd.application.document.DocumentCommandFacade;
@@ -182,6 +184,48 @@ public class DocumentController {
                 documentCommandFacade.updateDocument(id, user.getMember().getId(), request.toCommand(), toImageUploadParts(imageMetas, files))
         );
         return ResponseEntity.ok(ApiResponse.ok(dto, "문서가 수정되었습니다"));
+    }
+
+    @PatchMapping(value = "/v1/documents/{id}/folder", consumes = MediaType.APPLICATION_JSON_VALUE)
+    @Operation(
+            summary = "문서 폴더 이동",
+            description = """
+                    ### 개요
+                    - 문서 ID로 문서를 대상 폴더로 이동합니다.
+
+                    ### 인증
+                    - Authorization: Bearer {accessToken} (문서 작성자만)
+
+                    ### 요청
+                    - Path: /api/v1/documents/{id}/folder
+                    - Body(JSON, required)
+                      - folderId (number, required): 이동할 대상 폴더 ID
+                      - folderId가 0이면 루트로 이동합니다.
+
+                    ### 응답
+                    - 200 OK
+                    - data.documentId: 이동된 문서 ID
+                    - data.folderId: 이동 후 폴더 ID (루트면 null)
+
+                    ### 오류
+                    - DOC40401: 문서를 찾을 수 없음
+                    - DOC40301: 문서 소유자가 아님
+                    - FOLDER_NOT_FOUND: 폴더를 찾을 수 없음
+                    - FOLDER_FORBIDDEN: 폴더 소유자가 아님
+                    - REQ40001: JSON 파싱 실패 또는 잘못된 folderId
+                    - TOKEN4030x: 토큰 누락/만료/위조
+                    """
+    )
+    public ResponseEntity<ApiResponse<MoveDocumentFolderResponse>> moveDocumentFolder(
+            @Parameter(description = "이동할 문서 ID", example = "42")
+            @PathVariable("id") @Positive(message = "문서 ID는 1 이상이어야 합니다") Long id,
+            @Valid @RequestBody MoveDocumentFolderRequest request,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        MoveDocumentFolderResponse dto = MoveDocumentFolderResponse.from(
+                documentCommandFacade.moveDocumentFolder(id, user.getMember().getId(), request.toCommand())
+        );
+        return ResponseEntity.ok(ApiResponse.ok(dto, "문서 폴더가 이동되었습니다"));
     }
 
 

--- a/ssd-api/src/main/java/or/hyu/ssd/api/document/request/MoveDocumentFolderRequest.java
+++ b/ssd-api/src/main/java/or/hyu/ssd/api/document/request/MoveDocumentFolderRequest.java
@@ -1,0 +1,15 @@
+package or.hyu.ssd.api.document.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import or.hyu.ssd.document.application.command.MoveDocumentFolderCommand;
+
+public record MoveDocumentFolderRequest(
+        @NotNull(message = "폴더 ID는 필수입니다")
+        @PositiveOrZero(message = "폴더 ID는 0 이상이어야 합니다")
+        Long folderId
+) {
+    public MoveDocumentFolderCommand toCommand() {
+        return new MoveDocumentFolderCommand(folderId);
+    }
+}

--- a/ssd-api/src/main/java/or/hyu/ssd/api/document/response/MoveDocumentFolderResponse.java
+++ b/ssd-api/src/main/java/or/hyu/ssd/api/document/response/MoveDocumentFolderResponse.java
@@ -1,0 +1,12 @@
+package or.hyu.ssd.api.document.response;
+
+import or.hyu.ssd.document.application.result.MoveDocumentFolderResult;
+
+public record MoveDocumentFolderResponse(
+        Long documentId,
+        Long folderId
+) {
+    public static MoveDocumentFolderResponse from(MoveDocumentFolderResult result) {
+        return new MoveDocumentFolderResponse(result.documentId(), result.folderId());
+    }
+}

--- a/ssd-application/src/main/java/or/hyu/ssd/application/document/DocumentCommandFacade.java
+++ b/ssd-application/src/main/java/or/hyu/ssd/application/document/DocumentCommandFacade.java
@@ -2,9 +2,11 @@ package or.hyu.ssd.application.document;
 
 import lombok.RequiredArgsConstructor;
 import or.hyu.ssd.document.application.command.CreateDocumentCommand;
+import or.hyu.ssd.document.application.command.MoveDocumentFolderCommand;
 import or.hyu.ssd.document.application.command.UpdateDocumentCommand;
 import or.hyu.ssd.document.application.result.CreateDocumentResult;
 import or.hyu.ssd.document.application.result.DocumentBookmarkResult;
+import or.hyu.ssd.document.application.result.MoveDocumentFolderResult;
 import or.hyu.ssd.document.application.result.UpdateDocumentResult;
 import or.hyu.ssd.document.application.service.DocumentCommandService;
 import or.hyu.ssd.document.application.support.DocumentImageUploadPart;
@@ -43,6 +45,10 @@ public class DocumentCommandFacade {
             List<DocumentImageUploadPart> imageUploadParts
     ) {
         return documentCommandService.updateDocument(documentId, memberId, command, imageUploadParts);
+    }
+
+    public MoveDocumentFolderResult moveDocumentFolder(Long documentId, Long memberId, MoveDocumentFolderCommand command) {
+        return documentCommandService.moveDocumentFolder(documentId, memberId, command);
     }
 
     public void deleteDocument(Long documentId, Long memberId) {

--- a/ssd-domain/src/main/java/or/hyu/ssd/document/application/command/MoveDocumentFolderCommand.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/document/application/command/MoveDocumentFolderCommand.java
@@ -1,0 +1,4 @@
+package or.hyu.ssd.document.application.command;
+
+public record MoveDocumentFolderCommand(Long folderId) {
+}

--- a/ssd-domain/src/main/java/or/hyu/ssd/document/application/result/MoveDocumentFolderResult.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/document/application/result/MoveDocumentFolderResult.java
@@ -1,0 +1,10 @@
+package or.hyu.ssd.document.application.result;
+
+public record MoveDocumentFolderResult(
+        Long documentId,
+        Long folderId
+) {
+    public static MoveDocumentFolderResult of(Long documentId, Long folderId) {
+        return new MoveDocumentFolderResult(documentId, folderId);
+    }
+}

--- a/ssd-domain/src/main/java/or/hyu/ssd/document/application/service/DocumentCommandService.java
+++ b/ssd-domain/src/main/java/or/hyu/ssd/document/application/service/DocumentCommandService.java
@@ -20,9 +20,11 @@ import or.hyu.ssd.document.application.support.DocumentImageResolver;
 import or.hyu.ssd.document.application.support.DocumentImageUploadPart;
 import or.hyu.ssd.document.application.command.CreateDocumentCommand;
 import or.hyu.ssd.document.application.command.DocumentBlockCommand;
+import or.hyu.ssd.document.application.command.MoveDocumentFolderCommand;
 import or.hyu.ssd.document.application.command.UpdateDocumentCommand;
 import or.hyu.ssd.document.application.result.CreateDocumentResult;
 import or.hyu.ssd.document.application.result.DocumentBookmarkResult;
+import or.hyu.ssd.document.application.result.MoveDocumentFolderResult;
 import or.hyu.ssd.document.application.result.UpdateDocumentResult;
 import or.hyu.ssd.member.domain.model.Member;
 import or.hyu.ssd.member.repository.MemberRepository;
@@ -120,6 +122,19 @@ public class DocumentCommandService {
         documentRepository.save(document);
 
         return UpdateDocumentResult.of(document.getId());
+    }
+
+    public MoveDocumentFolderResult moveDocumentFolder(Long documentId, Long memberId, MoveDocumentFolderCommand command) {
+        validateMoveFolderRequest(command);
+        Document document = loadDocument(documentId);
+        assertDocumentOwner(document, memberId);
+
+        Folder folder = resolveFolderOrNull(memberId, command.folderId());
+        document.updateFolder(folder);
+        Document saved = documentRepository.save(document);
+
+        Long movedFolderId = saved.getFolder() == null ? null : saved.getFolder().getId();
+        return MoveDocumentFolderResult.of(saved.getId(), movedFolderId);
     }
 
     public void deleteDocument(Long documentId, Long memberId) {
@@ -222,6 +237,13 @@ public class DocumentCommandService {
         if (command.text() == null || command.text().trim().isEmpty()) {
             throw new DocumentException(ErrorCode.REQUEST_BODY_INVALID_VALUE, "내용은 공백일 수 없습니다");
         }
+    }
+
+    private void validateMoveFolderRequest(MoveDocumentFolderCommand command) {
+        if (command == null || command.folderId() == null) {
+            throw new DocumentException(ErrorCode.REQUEST_BODY_INVALID_VALUE, "폴더 ID는 필수입니다");
+        }
+        validateFolderId(command.folderId());
     }
 
     private void validateFolderId(Long folderId) {

--- a/ssd-domain/src/test/java/or/hyu/ssd/document/application/service/DocumentCommandServiceTest.java
+++ b/ssd-domain/src/test/java/or/hyu/ssd/document/application/service/DocumentCommandServiceTest.java
@@ -5,6 +5,7 @@ import or.hyu.ssd.document.domain.model.DocumentBlockType;
 import or.hyu.ssd.document.domain.model.DocumentLog;
 import or.hyu.ssd.document.domain.model.DocumentParagraph;
 import or.hyu.ssd.document.domain.model.DocumentPurpose;
+import or.hyu.ssd.document.domain.model.Folder;
 import or.hyu.ssd.document.repository.CheckListRepository;
 import or.hyu.ssd.document.repository.DocumentAiCheckSnapshotRepository;
 import or.hyu.ssd.document.repository.DocumentCommentRepository;
@@ -18,8 +19,10 @@ import or.hyu.ssd.document.application.support.DocumentImageResolver;
 import or.hyu.ssd.document.application.support.DocumentImageUploadPart;
 import or.hyu.ssd.document.application.command.CreateDocumentCommand;
 import or.hyu.ssd.document.application.command.DocumentBlockCommand;
+import or.hyu.ssd.document.application.command.MoveDocumentFolderCommand;
 import or.hyu.ssd.document.application.command.UpdateDocumentCommand;
 import or.hyu.ssd.document.application.result.CreateDocumentResult;
+import or.hyu.ssd.document.application.result.MoveDocumentFolderResult;
 import or.hyu.ssd.member.domain.model.Member;
 import or.hyu.ssd.member.domain.model.Role;
 import or.hyu.ssd.member.repository.MemberRepository;
@@ -43,6 +46,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -270,6 +274,122 @@ class DocumentCommandServiceTest {
     }
 
     @Test
+    @DisplayName("moveDocumentFolder()는 본인 문서를 본인 폴더로 이동한다")
+    void moveDocumentFolder_movesDocumentToOwnedFolder() {
+        // given
+        Member member = member(1L);
+        Document document = document(42L, member);
+        Folder targetFolder = folder(7L, member);
+        when(documentRepository.findById(42L)).thenReturn(Optional.of(document));
+        when(folderRepository.findById(7L)).thenReturn(Optional.of(targetFolder));
+        when(documentRepository.save(any(Document.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        MoveDocumentFolderResult result = documentCommandService.moveDocumentFolder(
+                42L,
+                member.getId(),
+                new MoveDocumentFolderCommand(7L)
+        );
+
+        // then
+        assertThat(document.getFolder()).isEqualTo(targetFolder);
+        assertThat(result.documentId()).isEqualTo(42L);
+        assertThat(result.folderId()).isEqualTo(7L);
+        verify(documentRepository).save(document);
+    }
+
+    @Test
+    @DisplayName("moveDocumentFolder()는 folderId가 0이면 문서를 루트로 이동한다")
+    void moveDocumentFolder_movesDocumentToRoot() {
+        // given
+        Member member = member(1L);
+        Document document = document(42L, member, folder(7L, member));
+        when(documentRepository.findById(42L)).thenReturn(Optional.of(document));
+        when(documentRepository.save(any(Document.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        MoveDocumentFolderResult result = documentCommandService.moveDocumentFolder(
+                42L,
+                member.getId(),
+                new MoveDocumentFolderCommand(0L)
+        );
+
+        // then
+        assertThat(document.getFolder()).isNull();
+        assertThat(result.documentId()).isEqualTo(42L);
+        assertThat(result.folderId()).isNull();
+        verify(folderRepository, never()).findById(any());
+        verify(documentRepository).save(document);
+    }
+
+    @Test
+    @DisplayName("moveDocumentFolder()는 다른 회원의 문서 이동을 거부한다")
+    void moveDocumentFolder_rejectsOtherMemberDocument() {
+        // given
+        Member owner = member(1L);
+        Document document = document(42L, owner);
+        when(documentRepository.findById(42L)).thenReturn(Optional.of(document));
+
+        // when
+        ThrowingCallable action = () -> documentCommandService.moveDocumentFolder(
+                42L,
+                2L,
+                new MoveDocumentFolderCommand(7L)
+        );
+
+        // then
+        assertThatThrownBy(action)
+                .isInstanceOf(or.hyu.ssd.common.exception.DocumentException.class);
+        verify(folderRepository, never()).findById(any());
+        verify(documentRepository, never()).save(any(Document.class));
+    }
+
+    @Test
+    @DisplayName("moveDocumentFolder()는 다른 회원의 폴더로 이동을 거부한다")
+    void moveDocumentFolder_rejectsOtherMemberFolder() {
+        // given
+        Member member = member(1L);
+        Member otherMember = member(2L);
+        Document document = document(42L, member);
+        Folder otherFolder = folder(7L, otherMember);
+        when(documentRepository.findById(42L)).thenReturn(Optional.of(document));
+        when(folderRepository.findById(7L)).thenReturn(Optional.of(otherFolder));
+
+        // when
+        ThrowingCallable action = () -> documentCommandService.moveDocumentFolder(
+                42L,
+                member.getId(),
+                new MoveDocumentFolderCommand(7L)
+        );
+
+        // then
+        assertThatThrownBy(action)
+                .isInstanceOf(or.hyu.ssd.common.exception.DocumentException.class);
+        verify(documentRepository, never()).save(any(Document.class));
+    }
+
+    @Test
+    @DisplayName("moveDocumentFolder()는 음수 folderId를 거부한다")
+    void moveDocumentFolder_rejectsNegativeFolderId() {
+        // given
+        MoveDocumentFolderCommand command = new MoveDocumentFolderCommand(-1L);
+
+        // when
+        ThrowingCallable action = () -> documentCommandService.moveDocumentFolder(
+                42L,
+                1L,
+                command
+        );
+
+        // then
+        assertThatThrownBy(action)
+                .isInstanceOf(or.hyu.ssd.common.exception.DocumentException.class)
+                .hasMessage("폴더 ID는 0 이상이어야 합니다");
+        verify(documentRepository, never()).findById(any());
+        verify(documentRepository, never()).save(any(Document.class));
+    }
+
+    @Test
     @DisplayName("createDocument()는 이미지 블록의 blobKey를 S3 URL로 치환해 저장한다")
     void createDocument_uploadsImageBlocksAndPersistsImageType() {
         // given
@@ -401,12 +521,26 @@ class DocumentCommandServiceTest {
     }
 
     private Document document(Long id, Member member) {
+        return document(id, member, null);
+    }
+
+    private Document document(Long id, Member member, Folder folder) {
         return Document.builder()
                 .id(id)
                 .title("문서 제목")
                 .content("문서 본문")
+                .folder(folder)
                 .bookmark(false)
                 .purpose(DocumentPurpose.WRITING)
+                .member(member)
+                .build();
+    }
+
+    private Folder folder(Long id, Member member) {
+        return Folder.builder()
+                .id(id)
+                .name("폴더")
+                .color("#FFFFFF")
                 .member(member)
                 .build();
     }


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #189 


<br>

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 문서 폴더 이동 API 구현했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * 문서 폴더 이동 기능 추가: 사용자가 문서를 특정 폴더로 이동하거나 루트로 이동할 수 있습니다. 다른 사용자의 폴더로의 이동은 방지되며, 유효한 폴더 ID 검증이 수행됩니다.

* **Tests**
  * 문서 폴더 이동의 다양한 시나리오(성공 케이스, 접근 권한 검증, 입력값 유효성 검증)에 대한 테스트가 추가되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capstone-ssd/ssd-server/pull/190?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->