### PR TITLE
[FIX] 문서 NUL 문자 정제 및 Discord 알림 길이 제한

### DIFF
--- a/ssd-api/src/main/java/or/hyu/ssd/api/document/request/CreateDocumentBlockRequest.java
+++ b/ssd-api/src/main/java/or/hyu/ssd/api/document/request/CreateDocumentBlockRequest.java
@@ -37,6 +37,13 @@ public record CreateDocumentBlockRequest(
     }
 
     public DocumentBlockCommand toCommand() {
-        return new DocumentBlockCommand(resolvedType(), content, role, blockId, blobKey, url);
+        return new DocumentBlockCommand(
+                resolvedType(),
+                RequestStringSanitizer.stripNullChar(content),
+                RequestStringSanitizer.stripNullChar(role),
+                blockId,
+                RequestStringSanitizer.stripNullChar(blobKey),
+                RequestStringSanitizer.stripNullChar(url)
+        );
     }
 }

--- a/ssd-api/src/main/java/or/hyu/ssd/api/document/request/CreateDocumentBlockRequest.java
+++ b/ssd-api/src/main/java/or/hyu/ssd/api/document/request/CreateDocumentBlockRequest.java
@@ -23,16 +23,18 @@ public record CreateDocumentBlockRequest(
 
     @AssertTrue(message = "문단 블록은 content와 role이 필요하고, 이미지 블록은 blobKey 또는 url이 필요합니다")
     public boolean isValidBlockStructure() {
+        String sanitizedRole = RequestStringSanitizer.stripNullChar(role);
+
         if (resolvedType().isParagraph()) {
             return StringUtils.hasText(content)
-                    && role != null
-                    && ROLE_PATTERN.matcher(role).matches()
+                    && sanitizedRole != null
+                    && ROLE_PATTERN.matcher(sanitizedRole).matches()
                     && !StringUtils.hasText(blobKey)
                     && !StringUtils.hasText(url);
         }
 
         return !StringUtils.hasText(content)
-                && !StringUtils.hasText(role)
+                && !StringUtils.hasText(sanitizedRole)
                 && (StringUtils.hasText(blobKey) || StringUtils.hasText(url));
     }
 

--- a/ssd-api/src/main/java/or/hyu/ssd/api/document/request/CreateDocumentRequest.java
+++ b/ssd-api/src/main/java/or/hyu/ssd/api/document/request/CreateDocumentRequest.java
@@ -21,8 +21,8 @@ public record CreateDocumentRequest(
 ) {
     public CreateDocumentCommand toCommand() {
         return new CreateDocumentCommand(
-                title,
-                text,
+                RequestStringSanitizer.stripNullChar(title),
+                RequestStringSanitizer.stripNullChar(text),
                 paragraphs == null ? null : paragraphs.stream().map(CreateDocumentBlockRequest::toCommand).toList(),
                 folderId,
                 purpose

--- a/ssd-api/src/main/java/or/hyu/ssd/api/document/request/RequestStringSanitizer.java
+++ b/ssd-api/src/main/java/or/hyu/ssd/api/document/request/RequestStringSanitizer.java
@@ -6,7 +6,7 @@ final class RequestStringSanitizer {
     }
 
     static String stripNullChar(String value) {
-        if (value == null || value.indexOf('\u0000') < 0) {
+        if (value == null || !value.contains("\u0000")) {
             return value;
         }
         return value.replace("\u0000", "");

--- a/ssd-api/src/main/java/or/hyu/ssd/api/document/request/RequestStringSanitizer.java
+++ b/ssd-api/src/main/java/or/hyu/ssd/api/document/request/RequestStringSanitizer.java
@@ -1,0 +1,14 @@
+package or.hyu.ssd.api.document.request;
+
+final class RequestStringSanitizer {
+
+    private RequestStringSanitizer() {
+    }
+
+    static String stripNullChar(String value) {
+        if (value == null || value.indexOf('\u0000') < 0) {
+            return value;
+        }
+        return value.replace("\u0000", "");
+    }
+}

--- a/ssd-api/src/main/java/or/hyu/ssd/api/document/request/UpdateDocumentRequest.java
+++ b/ssd-api/src/main/java/or/hyu/ssd/api/document/request/UpdateDocumentRequest.java
@@ -14,8 +14,8 @@ public record UpdateDocumentRequest(
 ) {
     public UpdateDocumentCommand toCommand() {
         return new UpdateDocumentCommand(
-                title,
-                text,
+                RequestStringSanitizer.stripNullChar(title),
+                RequestStringSanitizer.stripNullChar(text),
                 paragraphs == null ? null : paragraphs.stream().map(CreateDocumentBlockRequest::toCommand).toList()
         );
     }

--- a/ssd-api/src/test/java/or/hyu/ssd/api/document/request/CreateDocumentRequestValidationTest.java
+++ b/ssd-api/src/test/java/or/hyu/ssd/api/document/request/CreateDocumentRequestValidationTest.java
@@ -64,6 +64,29 @@ class CreateDocumentRequestValidationTest {
                 .contains("문서 목적은 필수입니다");
     }
 
+    @Test
+    @DisplayName("toCommand는 문자열의 NUL 문자(\\u0000)를 제거한다")
+    void toCommandStripsNullCharacter() {
+        // given
+        CreateDocumentRequest request = new CreateDocumentRequest(
+                "제목\u0000",
+                "본문\u0000텍스트",
+                Arrays.asList(new CreateDocumentBlockRequest(null, "문단\u0000내용", "\u0000##", 1, null, null)),
+                0L,
+                DocumentPurpose.WRITING
+        );
+
+        // when
+        var command = request.toCommand();
+
+        // then
+        assertThat(command.title()).isEqualTo("제목");
+        assertThat(command.text()).isEqualTo("본문텍스트");
+        assertThat(command.blocks()).hasSize(1);
+        assertThat(command.blocks().getFirst().content()).isEqualTo("문단내용");
+        assertThat(command.blocks().getFirst().role()).isEqualTo("##");
+    }
+
     private static Set<String> extractMessages(Set<? extends ConstraintViolation<?>> violations) {
         return violations.stream()
                 .map(ConstraintViolation::getMessage)

--- a/ssd-api/src/test/java/or/hyu/ssd/api/document/request/CreateDocumentRequestValidationTest.java
+++ b/ssd-api/src/test/java/or/hyu/ssd/api/document/request/CreateDocumentRequestValidationTest.java
@@ -87,6 +87,25 @@ class CreateDocumentRequestValidationTest {
         assertThat(command.blocks().getFirst().role()).isEqualTo("##");
     }
 
+    @Test
+    @DisplayName("검증 단계에서도 NUL 문자가 포함된 role을 허용한다")
+    void validationAllowsRoleContainingNullChar() {
+        // given
+        CreateDocumentRequest request = new CreateDocumentRequest(
+                "제목",
+                "본문",
+                Arrays.asList(new CreateDocumentBlockRequest(null, "문단", "\u0000##", 1, null, null)),
+                0L,
+                DocumentPurpose.WRITING
+        );
+
+        // when
+        Set<ConstraintViolation<CreateDocumentRequest>> violations = VALIDATOR.validate(request);
+
+        // then
+        assertThat(violations).isEmpty();
+    }
+
     private static Set<String> extractMessages(Set<? extends ConstraintViolation<?>> violations) {
         return violations.stream()
                 .map(ConstraintViolation::getMessage)

--- a/ssd-external/src/main/java/or/hyu/ssd/external/alert/discord/DiscordWebhookNotifier.java
+++ b/ssd-external/src/main/java/or/hyu/ssd/external/alert/discord/DiscordWebhookNotifier.java
@@ -134,7 +134,10 @@ public class DiscordWebhookNotifier implements ErrorAlertNotifier {
     }
 
     private String truncateForDiscord(String content) {
-        if (content == null || content.length() <= DISCORD_CONTENT_LIMIT) {
+        if (content == null) {
+            return "";
+        }
+        if (content.length() <= DISCORD_CONTENT_LIMIT) {
             return content;
         }
 

--- a/ssd-external/src/main/java/or/hyu/ssd/external/alert/discord/DiscordWebhookNotifier.java
+++ b/ssd-external/src/main/java/or/hyu/ssd/external/alert/discord/DiscordWebhookNotifier.java
@@ -26,6 +26,8 @@ public class DiscordWebhookNotifier implements ErrorAlertNotifier {
 
     private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(5);
     private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+    private static final int DISCORD_CONTENT_LIMIT = 2000;
+    private static final String TRUNCATION_SUFFIX = "\n...(truncated)";
 
     private final DiscordProperties discordProperties;
     private final Environment environment;
@@ -120,7 +122,7 @@ public class DiscordWebhookNotifier implements ErrorAlertNotifier {
     }
 
     private String buildPayload(String content) {
-        return "{\"content\":\"" + escapeJson(content) + "\"}";
+        return "{\"content\":\"" + escapeJson(truncateForDiscord(content)) + "\"}";
     }
 
     private String escapeJson(String value) {
@@ -129,5 +131,17 @@ public class DiscordWebhookNotifier implements ErrorAlertNotifier {
                 .replace("\"", "\\\"")
                 .replace("\r", "\\r")
                 .replace("\n", "\\n");
+    }
+
+    private String truncateForDiscord(String content) {
+        if (content == null || content.length() <= DISCORD_CONTENT_LIMIT) {
+            return content;
+        }
+
+        int maxPrefixLength = DISCORD_CONTENT_LIMIT - TRUNCATION_SUFFIX.length();
+        if (maxPrefixLength <= 0) {
+            return content.substring(0, DISCORD_CONTENT_LIMIT);
+        }
+        return content.substring(0, maxPrefixLength) + TRUNCATION_SUFFIX;
     }
 }

--- a/ssd-external/src/test/java/or/hyu/ssd/external/alert/discord/DiscordWebhookNotifierTest.java
+++ b/ssd-external/src/test/java/or/hyu/ssd/external/alert/discord/DiscordWebhookNotifierTest.java
@@ -1,0 +1,40 @@
+package or.hyu.ssd.external.alert.discord;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
+import or.hyu.ssd.external.config.DiscordProperties;
+
+import java.lang.reflect.Method;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DiscordWebhookNotifierTest {
+
+    @Test
+    @DisplayName("디스코드 본문이 2000자를 넘으면 잘라낸다")
+    void truncateMessageWhenContentTooLong() throws Exception {
+        DiscordWebhookNotifier notifier = new DiscordWebhookNotifier(new DiscordProperties(), new MockEnvironment());
+        Method truncateMethod = DiscordWebhookNotifier.class.getDeclaredMethod("truncateForDiscord", String.class);
+        truncateMethod.setAccessible(true);
+
+        String longMessage = "a".repeat(2100);
+        String truncated = (String) truncateMethod.invoke(notifier, longMessage);
+
+        assertThat(truncated.length()).isLessThanOrEqualTo(2000);
+        assertThat(truncated).endsWith("\n...(truncated)");
+    }
+
+    @Test
+    @DisplayName("디스코드 본문이 2000자 이하면 그대로 둔다")
+    void keepMessageWhenWithinLimit() throws Exception {
+        DiscordWebhookNotifier notifier = new DiscordWebhookNotifier(new DiscordProperties(), new MockEnvironment());
+        Method truncateMethod = DiscordWebhookNotifier.class.getDeclaredMethod("truncateForDiscord", String.class);
+        truncateMethod.setAccessible(true);
+
+        String message = "a".repeat(2000);
+        String truncated = (String) truncateMethod.invoke(notifier, message);
+
+        assertThat(truncated).isEqualTo(message);
+    }
+}

--- a/ssd-external/src/test/java/or/hyu/ssd/external/alert/discord/DiscordWebhookNotifierTest.java
+++ b/ssd-external/src/test/java/or/hyu/ssd/external/alert/discord/DiscordWebhookNotifierTest.java
@@ -26,6 +26,7 @@ class DiscordWebhookNotifierTest {
         // then
         assertThat(truncated.length()).isLessThanOrEqualTo(2000);
         assertThat(truncated).endsWith("\n...(truncated)");
+        assertThat(truncated).startsWith(longMessage.substring(0, 1985));
     }
 
     @Test
@@ -42,5 +43,20 @@ class DiscordWebhookNotifierTest {
 
         // then
         assertThat(truncated).isEqualTo(message);
+    }
+
+    @Test
+    @DisplayName("디스코드 본문이 null이면 빈 문자열을 반환한다")
+    void returnEmptyStringWhenContentIsNull() throws Exception {
+        // given
+        DiscordWebhookNotifier notifier = new DiscordWebhookNotifier(new DiscordProperties(), new MockEnvironment());
+        Method truncateMethod = DiscordWebhookNotifier.class.getDeclaredMethod("truncateForDiscord", String.class);
+        truncateMethod.setAccessible(true);
+
+        // when
+        String truncated = (String) truncateMethod.invoke(notifier, (String) null);
+
+        // then
+        assertThat(truncated).isEqualTo("");
     }
 }

--- a/ssd-external/src/test/java/or/hyu/ssd/external/alert/discord/DiscordWebhookNotifierTest.java
+++ b/ssd-external/src/test/java/or/hyu/ssd/external/alert/discord/DiscordWebhookNotifierTest.java
@@ -14,13 +14,16 @@ class DiscordWebhookNotifierTest {
     @Test
     @DisplayName("디스코드 본문이 2000자를 넘으면 잘라낸다")
     void truncateMessageWhenContentTooLong() throws Exception {
+        // given
         DiscordWebhookNotifier notifier = new DiscordWebhookNotifier(new DiscordProperties(), new MockEnvironment());
         Method truncateMethod = DiscordWebhookNotifier.class.getDeclaredMethod("truncateForDiscord", String.class);
         truncateMethod.setAccessible(true);
-
         String longMessage = "a".repeat(2100);
+
+        // when
         String truncated = (String) truncateMethod.invoke(notifier, longMessage);
 
+        // then
         assertThat(truncated.length()).isLessThanOrEqualTo(2000);
         assertThat(truncated).endsWith("\n...(truncated)");
     }
@@ -28,13 +31,16 @@ class DiscordWebhookNotifierTest {
     @Test
     @DisplayName("디스코드 본문이 2000자 이하면 그대로 둔다")
     void keepMessageWhenWithinLimit() throws Exception {
+        // given
         DiscordWebhookNotifier notifier = new DiscordWebhookNotifier(new DiscordProperties(), new MockEnvironment());
         Method truncateMethod = DiscordWebhookNotifier.class.getDeclaredMethod("truncateForDiscord", String.class);
         truncateMethod.setAccessible(true);
-
         String message = "a".repeat(2000);
+
+        // when
         String truncated = (String) truncateMethod.invoke(notifier, message);
 
+        // then
         assertThat(truncated).isEqualTo(message);
     }
 }


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #198 


<br><br>

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 문서 NUL 문자 정제 및 Discord 알림 길이 제한 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 문서 입력값의 널 문자 자동 제거 기능 추가

* **개선사항**
  * Discord 알림 메시지 길이를 2,000자로 제한하여 전송 안정성 향상

* **테스트**
  * 널 문자 제거 동작 검증 테스트 추가
  * Discord 메시지 길이 제한 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->